### PR TITLE
Small fixes to the readme instructions to specify the code must be run on the plugins folder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,22 @@ Your plugin *must* contain a `CHANGELOG.md` file.
 
 Your plugin must have an entrypoint with the same name as the folder, i.e. `hello-world/hello-world.php`.
 
+## Introduction
+
+To work on this repository we advise the use of the following instructions. Using `git sparse-checkout` will make sure you'll only download and work on files related to a specific block.
+
+### Sparse Checkout
+
+The instructions will show you how to use sparse-checkout to work on a single block. You can work on extra blocks on your site by running
+
+`git sparse-checkout add %block_name%`
+
+If you need to remove sparse-checkout functionality altogether, you can run:
+
+`git sparse-checkout disable`
+
+More information here: https://git-scm.com/docs/git-sparse-checkout
+
 ## Creating a new block
 
 You can add a new block to the monorepo by running the following steps. Make sure you're starting from the `wp-content/plugins` folder:
@@ -28,10 +44,9 @@ git push
 
 ```
 
-From here, you can start editing your block.
+From here, you can start editing your block and follow the regular process to do so.
 
-
-## Editing an existing block
+## Checkout and edit an existing block
 
 **Do not forget that changing a block will auto update it on all sites that use this block. Please be careful!**
 
@@ -54,6 +69,14 @@ When updating a **static** block — if we add any changes to the edit or save f
 
 ## Partner Agnostic
 
-Make sure that project-specific styles and data go into the project code and not the block in this repo
+Keep in mind that blocks in this repository can be installed on multiple sites.
 
-https://developer.wordpress.org/themes/features/block-stylesheets/#registering-a-block-stylesheet
+When you need to make any changes, make sure those changes (design and/or functionality) are applicable to any other sites and are improving upon the existing code.
+
+Make sure that project-specific styles and data go into the project code and not the block code in this repo .
+
+### Adding site / partner specific styles
+
+Any partner-specific styling rules should be added via a separate stylesheet that should be registered through https://developer.wordpress.org/themes/features/block-stylesheets/#registering-a-block-stylesheet
+
+### Adding site / partner specific styles

--- a/readme.md
+++ b/readme.md
@@ -10,9 +10,9 @@ Your plugin must have an entrypoint with the same name as the folder, i.e. `hell
 
 ## Creating a new block
 
-You can add a new block to the monorepo by running the following steps in any folder:
+You can add a new block to the monorepo by running the following steps. Make sure you're starting from the `wp-content/plugins` folder:
 
-```
+``` bash
 git clone --no-checkout --sparse https://github.com/a8cteam51/special-projects-blocks-monorepo/
 cd special-projects-blocks-monorepo
 npx @wordpress/create-block
@@ -37,7 +37,7 @@ From here, you can start editing your block.
 
 Start by downloading the block's zip file on your plugin folder
 
-```
+``` bash
 git clone --no-checkout --sparse https://github.com/a8cteam51/special-projects-blocks-monorepo/
 cd special-projects-blocks-monorepo
 git sparse-checkout init --cone

--- a/special-projects-blocks-monorepo.php
+++ b/special-projects-blocks-monorepo.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name:       Dynamic Table of Contents
- * Description:       Creates a table of contents that's dynamically (PHP) rendered.
+ * Plugin Name:       Special Projects Blocks Monorepo
+ * Description:       Aggregates the blocks we have created.
  * Requires at least: 6.1
  * Requires PHP:      8.0
  * Version:           0.3
@@ -10,7 +10,7 @@
  * Update URI:        https://github.com/a8cteam51/special-projects-blocks-monorepo/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain:       dynamic-table-of-contents
+ * Text Domain:       wpsp-blocks
  *
  * @package           wpsp
  */
@@ -22,14 +22,14 @@
  *
  * Example: /dynamic-table-of-contents/dynamic-table-of-contents.php
  */
-function load_add_downloaded_blocks(){
+function load_add_downloaded_blocks() {
 	$dirs = glob( dirname( __FILE__ ) . '/*', GLOB_ONLYDIR );
 
 	foreach ( $dirs as $dir ) {
 		if ( file_exists( $dir . DIRECTORY_SEPARATOR . basename( $dir ) . '.php' ) ) {
-			require $dir . DIRECTORY_SEPARATOR . basename( $dir ) . '.php';
+			include $dir . DIRECTORY_SEPARATOR . basename( $dir ) . '.php';
 		}
 	}
 }
 
-add_action( 'init', 'load_add_downloaded_blocks' );
+add_action( 'plugins_loaded', 'load_add_downloaded_blocks' );


### PR DESCRIPTION
changes to the instructions in README
fixes the hook being used to autoload the blocks on the sites