### PR TITLE
Add aria label to the button for accessibility.

### DIFF
--- a/light-dark-toggle/CHANGELOG.md
+++ b/light-dark-toggle/CHANGELOG.md
@@ -1,0 +1,2 @@
+0.2.0
+Add an aria-label to the color switching button for accessability

--- a/light-dark-toggle/light-dark-toggle.php
+++ b/light-dark-toggle/light-dark-toggle.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Light Dark Toggle
  * Description:       Allows a site to have a light and dark mode toggle.
- * Version:           0.1.0
+ * Version:           0.2.0
  * Requires at least: 6.7
  * Requires PHP:      7.4
  * Author:            The WordPress Contributors
@@ -51,4 +51,3 @@ add_filter(
 		return $blocks;
 	}
 );
-

--- a/light-dark-toggle/src/deprecated.js
+++ b/light-dark-toggle/src/deprecated.js
@@ -1,0 +1,25 @@
+import { useBlockProps } from '@wordpress/block-editor';
+
+const v1 = {
+	attributes: {
+		defaultMode: {
+			type: 'string',
+			default: 'light',
+		},
+	},
+	save( { attributes } ) {
+		const { defaultMode } = attributes;
+
+		const className = [ defaultMode ? `mode-${ defaultMode }` : '' ]
+		.join( ' ' )
+		.trim();
+		return (
+			<button
+				{ ...useBlockProps.save( { className } ) }
+				data-default-mode={ defaultMode }
+			></button>
+		);
+	}
+};
+
+export default [ v1 ];

--- a/light-dark-toggle/src/edit.js
+++ b/light-dark-toggle/src/edit.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __ , sprintf } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { useRefEffect } from '@wordpress/compose';
 import { useState } from '@wordpress/element';
@@ -6,6 +6,7 @@ import {
 	addToggleModeListener,
 	toggleColorMode,
 	updateToggleClass,
+	updateToggleAriaLabel,
 } from './shared';
 import { PanelBody, SelectControl } from '@wordpress/components';
 
@@ -50,7 +51,14 @@ export default function Edit( { attributes, setAttributes } ) {
 			return;
 		}
 		toggleColorMode( localWindow );
+		updateToggleAriaLabel( localWindow );
 	};
+
+	const ariaLabel = sprintf(
+		/* translators: %s: color mode */
+		__( 'Switch to %s mode', 'light-dark-toggle' ),
+		defaultMode
+	);
 
 	return (
 		<div>
@@ -87,6 +95,7 @@ export default function Edit( { attributes, setAttributes } ) {
 			<button
 				{ ...useBlockProps( { ref: containerRef } ) }
 				onClick={ toggle }
+				aria-label={ ariaLabel }
 			></button>
 		</div>
 	);

--- a/light-dark-toggle/src/index.js
+++ b/light-dark-toggle/src/index.js
@@ -3,10 +3,12 @@ import { registerBlockType } from '@wordpress/blocks';
 import Edit from './edit';
 import save from './save';
 import metadata from './block.json';
+import deprecated from './deprecated';
 
 import './style.scss';
 
 registerBlockType( metadata.name, {
 	edit: Edit,
 	save,
+	deprecated,
 } );

--- a/light-dark-toggle/src/save.js
+++ b/light-dark-toggle/src/save.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
@@ -7,11 +8,17 @@ export default function save( { attributes } ) {
 	const className = [ defaultMode ? `mode-${ defaultMode }` : '' ]
 		.join( ' ' )
 		.trim();
+	const label = sprintf(
+		/* translators: %s: color mode */
+		__( 'Switch to %s mode', 'light-dark-toggle' ),
+		defaultMode
+	);
 
 	return (
 		<button
 			{ ...useBlockProps.save( { className } ) }
 			data-default-mode={ defaultMode }
+			aria-label={ label }
 		></button>
 	);
 }

--- a/light-dark-toggle/src/shared.js
+++ b/light-dark-toggle/src/shared.js
@@ -1,3 +1,5 @@
+import { __, sprintf } from '@wordpress/i18n';
+
 let startingColorScheme = 'light';
 
 /**
@@ -74,4 +76,25 @@ export function updateToggleClass( window ) {
 		'wpcomsp-light-dark-active',
 		colorScheme === 'light'
 	);
+}
+
+/**
+ * Updates the aria label for the toggle button
+ * @param {window} window The window object
+ */
+export function updateToggleAriaLabel( window ) {
+	const toggle = window.document.querySelector( '.wp-block-wpcomsp-light-dark-toggle' );
+
+	if ( ! toggle ) {
+		return;
+	}
+
+	const colorScheme = getColorScheme( window );
+	const label = sprintf(
+		/* translators: %s: color mode */
+		__( 'Switch to %s mode', 'light-dark-toggle' ),
+		colorScheme
+	);
+
+	toggle.setAttribute( 'aria-label', label );
 }

--- a/light-dark-toggle/src/view.js
+++ b/light-dark-toggle/src/view.js
@@ -4,6 +4,7 @@ import {
 	getColorScheme,
 	toggleColorMode,
 	updateToggleClass,
+	updateToggleAriaLabel,
 } from './shared';
 
 domReady( wpcomDarkLightMode );
@@ -40,6 +41,7 @@ function wpcomDarkLightMode() {
 		}
 
 		toggleColorMode( window );
+		updateToggleAriaLabel( window );
 	} );
 
 	toggle?.addEventListener( 'pointermove', ( ev ) => {
@@ -91,9 +93,11 @@ function wpcomDarkLightMode() {
 		// click
 		if ( Math.abs( deltaX ) < 10 ) {
 			toggleColorMode( window );
+			updateToggleAriaLabel( window );
 			// slide
 		} else if ( newScheme !== getColorScheme( window ) ) {
 			toggleColorMode( window );
+			updateToggleAriaLabel( window );
 		}
 	}
 }


### PR DESCRIPTION
Having used this toggle on a site, [an issue has come up](https://github.com/a8cteam51/osscapital/issues/47) in functional QA testing regarding the accessibility of the toggle switch. To address this I have added an aria-label to the toggle which changes slightly when the toggle is checked.

```
The Switching Mode button (e.g., Light/Dark mode toggle) does not have accessible text or an ARIA label. This makes it difficult for screen readers and assistive technologies to convey its purpose to visually impaired users, impacting WCAG 2.1 compliance 
```

