### PR TITLE
Carousel: Prevent wp.org updates; package all files with `wp-scripts plugin-zip`

### DIFF
--- a/carousel/carousel.php
+++ b/carousel/carousel.php
@@ -9,6 +9,7 @@
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       carousel
+ * Update URI:        false
  *
  * @package wpcomsp
  */

--- a/carousel/package.json
+++ b/carousel/package.json
@@ -14,6 +14,9 @@
 		"plugin-zip": "wp-scripts plugin-zip",
 		"start": "wp-scripts start && wp-scripts build-blocks-manifest"
 	},
+	"files": [
+		"[^.]*"
+	],
 	"devDependencies": {
 		"@wordpress/scripts": "^30.13.0",
 		"clsx": "^2.1.1"


### PR DESCRIPTION
1. Add a `files` configuration to `package.json` so that all files and directories are included in the generated zip. (`wp dist-archive` may be better for this long term)
2. Set `Update URI` to `false` in the plugin header to prevent accidental override by the wp.org plugin.