### PR TITLE
Carousel Block: remove escaping from carousel content

### DIFF
--- a/carousel/includes/block.php
+++ b/carousel/includes/block.php
@@ -79,7 +79,7 @@ function render( array $attributes, string $content ): string {
 		wp_kses_data( get_block_wrapper_attributes( $extra_attributes ) ),
 		wp_kses_post( $arrows ),
 		wp_kses_post( $pagination ),
-		wp_kses_post( $content ),
+		$content,
 	);
 
 	return $block;


### PR DESCRIPTION
This is redundant, and can break certain embeds, etc.