### PR TITLE
Tabs: Use CSS class instead of [role='tab'] as selector when styling tab.

### DIFF
--- a/tabs/package.json
+++ b/tabs/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "tabs",
-	"version": "0.1.0",
+	"private": true,
+	"version": "0.1.1",
 	"description": "A block that allows users to organize content into tabs.",
 	"author": "WordPress Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"homepage": "https://wpspecialprojects.wordpress.com/",
-	"main": "build/tabs/index.js",
 	"scripts": {
 		"build": "wp-scripts build",
 		"format": "wp-scripts format",

--- a/tabs/src/tabs/edit.js
+++ b/tabs/src/tabs/edit.js
@@ -54,6 +54,7 @@ function TabButton( { clientId, isActiveTab, tabNumber, setActiveTab } ) {
 			id={ `tab-${ tabNumber }` }
 			type="button"
 			role="tab"
+			className='tab'
 			aria-selected={ isTabBlockSelected || isActiveTab }
 			aria-controls={ `tabpanel-${ tabNumber }` }
 			tabIndex={ isTabBlockSelected || isActiveTab ? undefined : '-1' }
@@ -126,19 +127,19 @@ function TabsEdit( {
 	const moveTabLeft = () => {
 		if ( activeTab > 1 ) {
 			const newActiveTab = activeTab - 1;
-			
+
 			// Create a new array with the reordered blocks
 			const newBlockOrder = [ ...tabBlocks ];
 			const currentBlock = newBlockOrder[ activeTab - 1 ];
 			const previousBlock = newBlockOrder[ activeTab - 2 ];
-			
+
 			// Swap the blocks
 			newBlockOrder[ activeTab - 2 ] = currentBlock;
 			newBlockOrder[ activeTab - 1 ] = previousBlock;
-			
+
 			// Replace the inner blocks with the reordered version
 			replaceInnerBlocks( clientId, newBlockOrder, false );
-			
+
 			// Update the active tab
 			setAttributes( { activeTab: newActiveTab } );
 		}
@@ -147,19 +148,19 @@ function TabsEdit( {
 	const moveTabRight = () => {
 		if ( activeTab < tabBlocks.length ) {
 			const newActiveTab = activeTab + 1;
-			
+
 			// Create a new array with the reordered blocks
 			const newBlockOrder = [ ...tabBlocks ];
 			const currentBlock = newBlockOrder[ activeTab - 1 ];
 			const nextBlock = newBlockOrder[ activeTab ];
-			
+
 			// Swap the blocks
 			newBlockOrder[ activeTab ] = currentBlock;
 			newBlockOrder[ activeTab - 1 ] = nextBlock;
-			
+
 			// Replace the inner blocks with the reordered version
 			replaceInnerBlocks( clientId, newBlockOrder, false );
-			
+
 			// Update the active tab
 			setAttributes( { activeTab: newActiveTab } );
 		}

--- a/tabs/src/tabs/edit.js
+++ b/tabs/src/tabs/edit.js
@@ -13,6 +13,7 @@ import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
+import isEqual from 'fast-deep-equal';
 
 /**
  * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
@@ -101,15 +102,11 @@ function TabsEdit( {
 	useEffect( () => {
 		if ( tabBlocks.length < activeTab ) {
 			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( { activeTab: 1 } );
+			setAttributes( { activeTab: tabBlocks.length > 0 ? 1 : 0 } );
 		}
 		if (
 			tabBlocks.length !== tabs.length ||
-			tabBlocks.some(
-				( block, index ) =>
-					JSON.stringify( block.attributes ) !==
-					JSON.stringify( tabs[ index ] )
-			)
+			tabBlocks.some( ( block, index ) => ! isEqual( block.attributes, tabs[ index ] ) )
 		) {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {

--- a/tabs/src/tabs/save.js
+++ b/tabs/src/tabs/save.js
@@ -9,6 +9,7 @@ function TabButton( { isSelected, tabNumber, title } ) {
 			id={ `tab-${ tabNumber }` }
 			type="button"
 			role="tab"
+			className='tab'
 			aria-selected={ isSelected }
 			aria-controls={ `tabpanel-${ tabNumber }` }
 			tabIndex={ isSelected ? undefined : '-1' }

--- a/tabs/src/tabs/style.scss
+++ b/tabs/src/tabs/style.scss
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-@use "@wordpress/base-styles/breakpoints" as *;
-@use "@wordpress/base-styles/mixins" as *;
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .wp-block-wpcomsp-tabs {
 	[role="tablist"] {
@@ -12,7 +12,7 @@
 		gap: 1px;
 	}
 
-	[role="tab"] {
+	.tab {
 		display: inline-block;
 		position: relative;
 		z-index: 2;
@@ -69,12 +69,12 @@
 			flex-direction: row;
 		}
 
-		[role="tab"] {
+		.tab {
 			max-width: 22%;
 			text-align: left;
 		}
 
-		[role="tab"] .tab-button-text {
+		.tab .tab-button-text {
 			min-height: 20px;
 		}
 	}

--- a/tabs/src/tabs/style.scss
+++ b/tabs/src/tabs/style.scss
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
+@use "@wordpress/base-styles/breakpoints" as *;
+@use "@wordpress/base-styles/mixins" as *;
 
 .wp-block-wpcomsp-tabs {
 	[role="tablist"] {

--- a/tabs/src/tabs/view.js
+++ b/tabs/src/tabs/view.js
@@ -19,7 +19,7 @@ class TabsAutomatic {
 		this.lastTab = null;
 
 		this.tabs = Array.from(
-			this.tablistNode.querySelectorAll( '[role=tab]' )
+			this.tablistNode.querySelectorAll( '.tab' )
 		);
 		this.tabpanels = [];
 

--- a/tabs/tabs.php
+++ b/tabs/tabs.php
@@ -5,7 +5,7 @@
  * Description:       A block that allows users to organize content into tabs.
  * Requires at least: 6.5
  * Requires PHP:      8.0
- * Version:           0.1.0
+ * Version:           0.1.1
  * Author:            WordPress Special Projects Team
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Use CSS `.tab` class as a selector instead of [role='tab'] so it works properly on WPCOM simple site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Tabs now include a dedicated CSS hook (class) for more consistent, theme-friendly styling.
  - Base style imports updated for improved styling alignment.
- Refactor
  - Tab initialization now targets class-based tab elements; behavior, selection, and accessibility remain unchanged.
- New Features
  - None
- Bug Fixes
  - None
<!-- end of auto-generated comment: release notes by coderabbit.ai -->