### PR TITLE
Tabs: Use 'div' instead of 'button' in Tabs menu.

### DIFF
--- a/tabs/src/tabs/edit.js
+++ b/tabs/src/tabs/edit.js
@@ -51,7 +51,7 @@ function TabButton( { clientId, isActiveTab, tabNumber, setActiveTab } ) {
 	};
 
 	return (
-		<button
+		<div
 			id={ `tab-${ tabNumber }` }
 			type="button"
 			role="tab"
@@ -75,7 +75,7 @@ function TabButton( { clientId, isActiveTab, tabNumber, setActiveTab } ) {
 				className="tab-button-text"
 				disableLineBreaks
 			/>
-		</button>
+		</div>
 	);
 }
 

--- a/tabs/src/tabs/edit.js
+++ b/tabs/src/tabs/edit.js
@@ -51,7 +51,7 @@ function TabButton( { clientId, isActiveTab, tabNumber, setActiveTab } ) {
 	};
 
 	return (
-		<div
+		<a
 			id={ `tab-${ tabNumber }` }
 			type="button"
 			role="tab"
@@ -75,7 +75,7 @@ function TabButton( { clientId, isActiveTab, tabNumber, setActiveTab } ) {
 				className="tab-button-text"
 				disableLineBreaks
 			/>
-		</div>
+		</a>
 	);
 }
 

--- a/tabs/src/tabs/edit.js
+++ b/tabs/src/tabs/edit.js
@@ -51,7 +51,7 @@ function TabButton( { clientId, isActiveTab, tabNumber, setActiveTab } ) {
 	};
 
 	return (
-		<a
+		<div
 			id={ `tab-${ tabNumber }` }
 			type="button"
 			role="tab"
@@ -75,7 +75,7 @@ function TabButton( { clientId, isActiveTab, tabNumber, setActiveTab } ) {
 				className="tab-button-text"
 				disableLineBreaks
 			/>
-		</a>
+		</div>
 	);
 }
 

--- a/tabs/src/tabs/save.js
+++ b/tabs/src/tabs/save.js
@@ -13,7 +13,6 @@ function TabButton( { isSelected, tabNumber, title } ) {
 			aria-selected={ isSelected }
 			aria-controls={ `tabpanel-${ tabNumber }` }
 			tabIndex={ isSelected ? undefined : '-1' }
-			href="#"
 		>
 			<RichText.Content
 				tagName="span"

--- a/tabs/src/tabs/save.js
+++ b/tabs/src/tabs/save.js
@@ -5,7 +5,7 @@ import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
 
 function TabButton( { isSelected, tabNumber, title } ) {
 	return (
-		<a
+		<div
 			id={ `tab-${ tabNumber }` }
 			type="button"
 			role="tab"
@@ -13,13 +13,14 @@ function TabButton( { isSelected, tabNumber, title } ) {
 			aria-selected={ isSelected }
 			aria-controls={ `tabpanel-${ tabNumber }` }
 			tabIndex={ isSelected ? undefined : '-1' }
+			href="#"
 		>
 			<RichText.Content
 				tagName="span"
 				value={ title }
 				className="tab-button-text"
 			/>
-		</a>
+		</div>
 	);
 }
 

--- a/tabs/src/tabs/save.js
+++ b/tabs/src/tabs/save.js
@@ -5,7 +5,7 @@ import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
 
 function TabButton( { isSelected, tabNumber, title } ) {
 	return (
-		<button
+		<div
 			id={ `tab-${ tabNumber }` }
 			type="button"
 			role="tab"
@@ -19,7 +19,7 @@ function TabButton( { isSelected, tabNumber, title } ) {
 				value={ title }
 				className="tab-button-text"
 			/>
-		</button>
+		</div>
 	);
 }
 

--- a/tabs/src/tabs/save.js
+++ b/tabs/src/tabs/save.js
@@ -5,7 +5,7 @@ import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
 
 function TabButton( { isSelected, tabNumber, title } ) {
 	return (
-		<div
+		<a
 			id={ `tab-${ tabNumber }` }
 			type="button"
 			role="tab"
@@ -19,7 +19,7 @@ function TabButton( { isSelected, tabNumber, title } ) {
 				value={ title }
 				className="tab-button-text"
 			/>
-		</div>
+		</a>
 	);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved tab accessibility and keyboard/focus behavior, ensuring correct role and selection states for assistive technologies.

- Refactor
  - Unified tab component structure between editor and front-end for consistent behavior and styling.

- Chores
  - Minor markup adjustments to improve compatibility and maintainability without changing user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->