### PR TITLE
Tabs: Update tabs block to version 0.1.2

### DIFF
--- a/tabs/package-lock.json
+++ b/tabs/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tabs",
-	"version": "0.1.0",
+	"version": "0.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tabs",
-			"version": "0.1.0",
+			"version": "0.1.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/icons": "^10.3.0"

--- a/tabs/package.json
+++ b/tabs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tabs",
 	"private": true,
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "A block that allows users to organize content into tabs.",
 	"author": "WordPress Special Projects Team",
 	"license": "GPL-2.0-or-later",

--- a/tabs/src/tab/block.json
+++ b/tabs/src/tab/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "wpcomsp/tab",
-	"version": "0.1.0",
+	"version": "0.1.2",
 	"title": "Tab",
 	"category": "widgets",
 	"description": "Customize content inside a tab.",

--- a/tabs/src/tabs/block.json
+++ b/tabs/src/tabs/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "wpcomsp/tabs",
-	"version": "0.1.0",
+	"version": "0.1.2",
 	"title": "Tabs",
 	"category": "widgets",
 	"description": "Organize content using tabs.",

--- a/tabs/src/tabs/edit.js
+++ b/tabs/src/tabs/edit.js
@@ -57,7 +57,6 @@ function TabButton( { clientId, isActiveTab, tabNumber, setActiveTab } ) {
 			className='tab'
 			aria-selected={ isTabBlockSelected || isActiveTab }
 			aria-controls={ `tabpanel-${ tabNumber }` }
-			tabIndex={ isTabBlockSelected || isActiveTab ? undefined : '-1' }
 			onClick={ setActiveTab }
 		>
 			<RichText

--- a/tabs/src/tabs/edit.js
+++ b/tabs/src/tabs/edit.js
@@ -53,7 +53,6 @@ function TabButton( { clientId, isActiveTab, tabNumber, setActiveTab } ) {
 	return (
 		<div
 			id={ `tab-${ tabNumber }` }
-			type="button"
 			role="tab"
 			className='tab'
 			aria-selected={ isTabBlockSelected || isActiveTab }

--- a/tabs/src/tabs/save.js
+++ b/tabs/src/tabs/save.js
@@ -7,7 +7,6 @@ function TabButton( { isSelected, tabNumber, title } ) {
 	return (
 		<div
 			id={ `tab-${ tabNumber }` }
-			type="button"
 			role="tab"
 			className='tab'
 			aria-selected={ isSelected }

--- a/tabs/src/tabs/save.js
+++ b/tabs/src/tabs/save.js
@@ -11,7 +11,6 @@ function TabButton( { isSelected, tabNumber, title } ) {
 			className='tab'
 			aria-selected={ isSelected }
 			aria-controls={ `tabpanel-${ tabNumber }` }
-			tabIndex={ isSelected ? undefined : '-1' }
 		>
 			<RichText.Content
 				tagName="span"


### PR DESCRIPTION
Bump Tabs block version to 0.1.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package and block manifest versions to 0.1.2 for consistency and release alignment.

* **Accessibility**
  * Removed explicit focus management on tab elements; tabs now rely on default keyboard focus behavior — may change keyboard navigation behavior for some users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->