### PR TITLE
Fix Missing Title - Coalescing operator syntax error in render.php

### DIFF
--- a/dynamic-table-of-contents/src/render.php
+++ b/dynamic-table-of-contents/src/render.php
@@ -24,7 +24,7 @@ wp_enqueue_script(
 
 <div <?php echo wp_kses_post( get_block_wrapper_attributes() ); ?>>
 	<?php
-	$block_title = isset( $attributes['title'] ) ?? '';
+	$block_title = $attributes['title'] ?? '';
 	$block_title = apply_filters( 'wpcomsp_dynamic_table_of_contents_block_title', $block_title, $attributes );
 
 	if ( ! empty( $block_title ) ) {


### PR DESCRIPTION
## Description
Fixed: Incorrect `isset()` usage with null coalescing operator in dynamic table of contents block

## Summary
**Bug Fixes**

- Fixed syntax error where `isset()` was incorrectly combined with null coalescing operator (`??`) returning boolean value instead. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Table of Contents title handling so the configured title displays correctly instead of a placeholder or incorrect value.
  * Ensures the title is shown only when provided, and remains hidden when left blank, improving consistency in rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->