### PR TITLE
Update block version and author, enable className support

### DIFF
--- a/stretchy-type/package.json
+++ b/stretchy-type/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "stretchy-type",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "A block that expands to fill the width of its container.",
-	"author": "Studio 51",
+	"author": "Automattic Special Projects",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/stretchy-type/src/block.json
+++ b/stretchy-type/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "wpsp/stretchy-type",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"title": "Stretchy Type",
 	"category": "theme",
 	"icon": "text",

--- a/stretchy-type/src/index.js
+++ b/stretchy-type/src/index.js
@@ -19,6 +19,7 @@ const unsubscribe = subscribe( () => {
 			save,
 			supports: {
 				...paragraphBlockType.supports,
+				className: true,
 				typography: {
 					...paragraphBlockType.supports.typography,
 					fontSize: false,

--- a/stretchy-type/src/save.js
+++ b/stretchy-type/src/save.js
@@ -21,7 +21,6 @@ export default function save( { attributes } ) {
 	const { content, viewBox } = attributes;
 	const blockProps = useBlockProps.save( {
 		viewBox: viewBox ? viewBox : null,
-		className: 'wp-block-wpsp-stretchy-type',
 	} );
 
 	return (

--- a/stretchy-type/stretchy-type.php
+++ b/stretchy-type/stretchy-type.php
@@ -4,10 +4,9 @@
  * Description:       A block that expands to fill the width of its container.
  * Requires at least: 6.1
  * Requires PHP:      7.0
- * Version:           0.1.2
- * Author:            Studio 51
+ * Version:           0.1.3
+ * Author:            Automattic Special Projects
  * Author URI:        https://wpspecialprojects.wordpress.com/
- * Update URI:        https://opsoasis.wpspecialprojects.com/stretchy-type/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       stretchy-type


### PR DESCRIPTION
Bumped version to 0.1.3 and updated author to Automattic Special Projects in package.json, block.json, and PHP file. Enabled className support for the block and removed hardcoded className from save.js to allow custom class names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Block now supports custom CSS classes (via “Additional CSS class(es)” in settings).
- Refactor
  - Removed the hardcoded wrapper CSS class from saved markup; update any styles that relied on it.
- Chores
  - Bumped version to 0.1.3 across plugin and block metadata.
  - Updated author information to Automattic Special Projects.
  - Updated plugin Update URI metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->