### PR TITLE
Tabs: Improve Tab button UX for long tabs.

### DIFF
--- a/tabs/src/tabs/edit.js
+++ b/tabs/src/tabs/edit.js
@@ -181,7 +181,7 @@ function TabsEdit( {
 				<div className="tabs-container">
 					<div
 						className="scroll-arrow scroll-arrow-left"
-						aria-label="Scroll tabs left"
+						aria-label={ __( 'Scroll tabs left', 'tabs' ) }
 						role="button"
 						tabIndex="0"
 					></div>
@@ -205,7 +205,7 @@ function TabsEdit( {
 					</div>
 					<div
 						className="scroll-arrow scroll-arrow-right"
-						aria-label="Scroll tabs right"
+						aria-label={ __( 'Scroll tabs right', 'tabs' ) }
 						role="button"
 						tabIndex="0"
 					></div>

--- a/tabs/src/tabs/edit.js
+++ b/tabs/src/tabs/edit.js
@@ -183,7 +183,6 @@ function TabsEdit( {
 						className="scroll-arrow scroll-arrow-left"
 						aria-label={ __( 'Scroll tabs left', 'tabs' ) }
 						role="button"
-						tabIndex="0"
 					></div>
 					<div role="tablist" className="tablist-wrapper">
 						{ tabBlocks.map( ( tabBlock, index ) => {
@@ -207,7 +206,6 @@ function TabsEdit( {
 						className="scroll-arrow scroll-arrow-right"
 						aria-label={ __( 'Scroll tabs right', 'tabs' ) }
 						role="button"
-						tabIndex="0"
 					></div>
 				</div>
 				<InnerBlocks

--- a/tabs/src/tabs/edit.js
+++ b/tabs/src/tabs/edit.js
@@ -178,23 +178,37 @@ function TabsEdit( {
 				/>
 			</BlockControls>
 			<div { ...blockProps }>
-				<div role="tablist">
-					{ tabBlocks.map( ( tabBlock, index ) => {
-						const tabNumber = index + 1;
-						return (
-							<TabButton
-								key={ tabBlock.clientId }
-								clientId={ tabBlock.clientId }
-								isActiveTab={
-									! hasTabSelected && activeTab === tabNumber
-								}
-								tabNumber={ tabNumber }
-								setActiveTab={ setAttributes.bind( null, {
-									activeTab: tabNumber,
-								} ) }
-							/>
-						);
-					} ) }
+				<div className="tabs-container">
+					<div
+						className="scroll-arrow scroll-arrow-left"
+						aria-label="Scroll tabs left"
+						role="button"
+						tabIndex="0"
+					></div>
+					<div role="tablist" className="tablist-wrapper">
+						{ tabBlocks.map( ( tabBlock, index ) => {
+							const tabNumber = index + 1;
+							return (
+								<TabButton
+									key={ tabBlock.clientId }
+									clientId={ tabBlock.clientId }
+									isActiveTab={
+										! hasTabSelected && activeTab === tabNumber
+									}
+									tabNumber={ tabNumber }
+									setActiveTab={ setAttributes.bind( null, {
+										activeTab: tabNumber,
+									} ) }
+								/>
+							);
+						} ) }
+					</div>
+					<div
+						className="scroll-arrow scroll-arrow-right"
+						aria-label="Scroll tabs right"
+						role="button"
+						tabIndex="0"
+					></div>
 				</div>
 				<InnerBlocks
 					__experimentalCaptureToolbars

--- a/tabs/src/tabs/editor.scss
+++ b/tabs/src/tabs/editor.scss
@@ -12,6 +12,11 @@
 		}
 	}
 
+	// Hide scroll arrows in editor
+	.scroll-arrow {
+		display: none !important;
+	}
+
 	.tab-button-text {
 		display: inline-block;
 		min-width: 60px;

--- a/tabs/src/tabs/save.js
+++ b/tabs/src/tabs/save.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 
 function TabButton( { isSelected, tabNumber, title } ) {
 	return (
@@ -46,7 +47,7 @@ export default function save( { attributes: { tabs } } ) {
 					className="scroll-arrow scroll-arrow-left"
 					role="button"
 					tabIndex="0"
-					aria-label="Scroll tabs left"
+					aria-label={ __( 'Scroll tabs left', 'tabs' ) }
 				></div>
 				<div role="tablist" className="tablist-wrapper">
 					{ tabButtons }
@@ -55,7 +56,7 @@ export default function save( { attributes: { tabs } } ) {
 					className="scroll-arrow scroll-arrow-right"
 					role="button"
 					tabIndex="0"
-					aria-label="Scroll tabs right"
+					aria-label={ __( 'Scroll tabs right', 'tabs' ) }
 				></div>
 			</div>
 			<InnerBlocks.Content />

--- a/tabs/src/tabs/save.js
+++ b/tabs/src/tabs/save.js
@@ -46,7 +46,6 @@ export default function save( { attributes: { tabs } } ) {
 				<div
 					className="scroll-arrow scroll-arrow-left"
 					role="button"
-					tabIndex="0"
 					aria-label={ __( 'Scroll tabs left', 'tabs' ) }
 				></div>
 				<div role="tablist" className="tablist-wrapper">
@@ -55,7 +54,6 @@ export default function save( { attributes: { tabs } } ) {
 				<div
 					className="scroll-arrow scroll-arrow-right"
 					role="button"
-					tabIndex="0"
 					aria-label={ __( 'Scroll tabs right', 'tabs' ) }
 				></div>
 			</div>

--- a/tabs/src/tabs/save.js
+++ b/tabs/src/tabs/save.js
@@ -41,7 +41,23 @@ export default function save( { attributes: { tabs } } ) {
 
 	return (
 		<div { ...blockProps }>
-			<div role="tablist">{ tabButtons }</div>
+			<div className="tabs-container">
+				<div
+					className="scroll-arrow scroll-arrow-left"
+					role="button"
+					tabIndex="0"
+					aria-label="Scroll tabs left"
+				></div>
+				<div role="tablist" className="tablist-wrapper">
+					{ tabButtons }
+				</div>
+				<div
+					className="scroll-arrow scroll-arrow-right"
+					role="button"
+					tabIndex="0"
+					aria-label="Scroll tabs right"
+				></div>
+			</div>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/tabs/src/tabs/style.scss
+++ b/tabs/src/tabs/style.scss
@@ -28,6 +28,10 @@
 		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 		transition: all 0.2s ease;
 
+		&.hidden {
+			display: none !important;
+		}
+
 		&::before {
 			content: '';
 			display: inline-block;

--- a/tabs/src/tabs/style.scss
+++ b/tabs/src/tabs/style.scss
@@ -5,11 +5,87 @@
 @use "@wordpress/base-styles/mixins" as *;
 
 .wp-block-wpcomsp-tabs {
+	.tabs-container {
+		display: flex;
+		align-items: center;
+		position: relative;
+		width: 100%;
+	}
+
+	.scroll-arrow {
+		display: none;
+		position: absolute;
+		top: 50%;
+		transform: translateY(-50%);
+		z-index: 10;
+		background: rgba(255, 255, 255, 0.9);
+		border: 1px solid #ccc;
+		border-radius: 4px;
+		padding: 8px 12px;
+		cursor: pointer;
+		font-size: 16px;
+		font-weight: bold;
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+		transition: all 0.2s ease;
+
+		&::before {
+			content: '';
+			display: inline-block;
+			width: 0;
+			height: 0;
+			border-style: solid;
+		}
+
+		&:hover {
+			background: rgba(255, 255, 255, 1);
+			box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+		}
+
+		&:disabled {
+			opacity: 0.5;
+			cursor: not-allowed;
+		}
+
+		&.scroll-arrow-left {
+			left: 0;
+
+			&::before {
+				border-width: 6px 8px 6px 0;
+				border-color: transparent #333 transparent transparent;
+			}
+		}
+
+		&.scroll-arrow-right {
+			right: 0;
+
+			&::before {
+				border-width: 6px 0 6px 8px;
+				border-color: transparent transparent transparent #333;
+			}
+		}
+	}
+
+	.tablist-wrapper {
+		flex: 1;
+		overflow: hidden;
+		position: relative;
+	}
+
 	[role="tablist"] {
 		min-width: 100%;
 		display: flex;
 		flex-direction: column;
 		gap: 1px;
+		overflow-x: auto;
+		overflow-y: hidden;
+		scroll-behavior: smooth;
+		-webkit-overflow-scrolling: touch;
+		scrollbar-width: none;
+		-ms-overflow-style: none;
+
+		&::-webkit-scrollbar {
+			display: none;
+		}
 	}
 
 	.tab {
@@ -65,13 +141,29 @@
 	}
 
 	@include break-mobile {
+		.scroll-arrow {
+			display: block;
+		}
+
 		[role="tablist"] {
 			flex-direction: row;
+			overflow-x: auto;
+			overflow-y: hidden;
+			scroll-behavior: smooth;
+			-webkit-overflow-scrolling: touch;
+			scrollbar-width: none;
+			-ms-overflow-style: none;
+
+			&::-webkit-scrollbar {
+				display: none;
+			}
 		}
 
 		.tab {
 			max-width: 22%;
 			text-align: left;
+			flex-shrink: 0;
+			min-width: fit-content;
 		}
 
 		.tab .tab-button-text {

--- a/tabs/src/tabs/view.js
+++ b/tabs/src/tabs/view.js
@@ -149,27 +149,27 @@ class TabsScrollHandler {
 	bindEvents() {
 		// Scroll arrow click events
 		this.leftArrow.addEventListener( 'click', () => {
-			if ( this.leftArrow.style.display !== 'none' ) {
+			if ( ! this.leftArrow.classList.contains( 'hidden' ) ) {
 				this.scrollLeft();
 			}
 		} );
 
 		this.rightArrow.addEventListener( 'click', () => {
-			if ( this.rightArrow.style.display !== 'none' ) {
+			if ( ! this.rightArrow.classList.contains( 'hidden' ) ) {
 				this.scrollRight();
 			}
 		} );
 
 		// Keyboard support for scroll arrows
 		this.leftArrow.addEventListener( 'keydown', ( event ) => {
-			if ( ( event.key === 'Enter' || event.key === ' ' ) && this.leftArrow.style.display !== 'none' ) {
+			if ( ( event.key === 'Enter' || event.key === ' ' ) && ! this.leftArrow.classList.contains( 'hidden' ) ) {
 				event.preventDefault();
 				this.scrollLeft();
 			}
 		} );
 
 		this.rightArrow.addEventListener( 'keydown', ( event ) => {
-			if ( ( event.key === 'Enter' || event.key === ' ' ) && this.rightArrow.style.display !== 'none' ) {
+			if ( ( event.key === 'Enter' || event.key === ' ' ) && ! this.rightArrow.classList.contains( 'hidden' ) ) {
 				event.preventDefault();
 				this.scrollRight();
 			}
@@ -208,30 +208,24 @@ class TabsScrollHandler {
 
 		// Show/hide arrows based on scrollability
 		if ( ! isScrollable ) {
-			this.leftArrow.style.display = 'none';
-			this.rightArrow.style.display = 'none';
+			this.leftArrow.classList.add( 'hidden' );
+			this.rightArrow.classList.add( 'hidden' );
 			return;
 		}
 
 		// Show/hide arrows based on scroll position
 		// Left arrow: hide when at the beginning, show when there's content to scroll left
 		if ( scrollLeft <= 0 ) {
-			this.leftArrow.style.display = 'none';
+			this.leftArrow.classList.add( 'hidden' );
 		} else {
-			this.leftArrow.style.display = 'block';
-			this.leftArrow.removeAttribute( 'disabled' );
-			this.leftArrow.style.opacity = '1';
-			this.leftArrow.style.cursor = 'pointer';
+			this.leftArrow.classList.remove( 'hidden' );
 		}
 
 		// Right arrow: hide when at the end, show when there's content to scroll right
 		if ( scrollLeft >= scrollWidth - clientWidth - 1 ) {
-			this.rightArrow.style.display = 'none';
+			this.rightArrow.classList.add( 'hidden' );
 		} else {
-			this.rightArrow.style.display = 'block';
-			this.rightArrow.removeAttribute( 'disabled' );
-			this.rightArrow.style.opacity = '1';
-			this.rightArrow.style.cursor = 'pointer';
+			this.rightArrow.classList.remove( 'hidden' );
 		}
 	}
 

--- a/tabs/src/tabs/view.js
+++ b/tabs/src/tabs/view.js
@@ -126,6 +126,124 @@ class TabsAutomatic {
 	}
 }
 
+class TabsScrollHandler {
+	constructor( container ) {
+		this.container = container;
+		this.tablist = container.querySelector( '[role="tablist"]' );
+		this.leftArrow = container.querySelector( '.scroll-arrow-left' );
+		this.rightArrow = container.querySelector( '.scroll-arrow-right' );
+
+		if ( ! this.tablist || ! this.leftArrow || ! this.rightArrow ) {
+			return;
+		}
+
+		this.init();
+	}
+
+	init() {
+		this.updateArrowVisibility();
+		this.bindEvents();
+		this.handleResize();
+	}
+
+	bindEvents() {
+		// Scroll arrow click events
+		this.leftArrow.addEventListener( 'click', () => {
+			if ( this.leftArrow.style.display !== 'none' ) {
+				this.scrollLeft();
+			}
+		} );
+
+		this.rightArrow.addEventListener( 'click', () => {
+			if ( this.rightArrow.style.display !== 'none' ) {
+				this.scrollRight();
+			}
+		} );
+
+		// Keyboard support for scroll arrows
+		this.leftArrow.addEventListener( 'keydown', ( event ) => {
+			if ( ( event.key === 'Enter' || event.key === ' ' ) && this.leftArrow.style.display !== 'none' ) {
+				event.preventDefault();
+				this.scrollLeft();
+			}
+		} );
+
+		this.rightArrow.addEventListener( 'keydown', ( event ) => {
+			if ( ( event.key === 'Enter' || event.key === ' ' ) && this.rightArrow.style.display !== 'none' ) {
+				event.preventDefault();
+				this.scrollRight();
+			}
+		} );
+
+		// Tablist scroll event
+		this.tablist.addEventListener( 'scroll', () => {
+			this.updateArrowVisibility();
+		} );
+
+		// Window resize event
+		window.addEventListener( 'resize', () => {
+			this.handleResize();
+		} );
+	}
+
+	scrollLeft() {
+		const scrollAmount = this.tablist.clientWidth * 0.8;
+		this.tablist.scrollBy( {
+			left: -scrollAmount,
+			behavior: 'smooth'
+		} );
+	}
+
+	scrollRight() {
+		const scrollAmount = this.tablist.clientWidth * 0.8;
+		this.tablist.scrollBy( {
+			left: scrollAmount,
+			behavior: 'smooth'
+		} );
+	}
+
+	updateArrowVisibility() {
+		const { scrollLeft, scrollWidth, clientWidth } = this.tablist;
+		const isScrollable = scrollWidth > clientWidth;
+
+		// Show/hide arrows based on scrollability
+		if ( ! isScrollable ) {
+			this.leftArrow.style.display = 'none';
+			this.rightArrow.style.display = 'none';
+			return;
+		}
+
+		// Show/hide arrows based on scroll position
+		// Left arrow: hide when at the beginning, show when there's content to scroll left
+		if ( scrollLeft <= 0 ) {
+			this.leftArrow.style.display = 'none';
+		} else {
+			this.leftArrow.style.display = 'block';
+			this.leftArrow.removeAttribute( 'disabled' );
+			this.leftArrow.style.opacity = '1';
+			this.leftArrow.style.cursor = 'pointer';
+		}
+
+		// Right arrow: hide when at the end, show when there's content to scroll right
+		if ( scrollLeft >= scrollWidth - clientWidth - 1 ) {
+			this.rightArrow.style.display = 'none';
+		} else {
+			this.rightArrow.style.display = 'block';
+			this.rightArrow.removeAttribute( 'disabled' );
+			this.rightArrow.style.opacity = '1';
+			this.rightArrow.style.cursor = 'pointer';
+		}
+	}
+
+	handleResize() {
+		// Debounce resize handling
+		clearTimeout( this.resizeTimeout );
+		this.resizeTimeout = setTimeout( () => {
+			this.updateArrowVisibility();
+		}, 100 );
+	}
+}
+
 // Initialize tablists.
 window.addEventListener( 'load', function () {
 	const tablists = document.querySelectorAll(
@@ -133,5 +251,13 @@ window.addEventListener( 'load', function () {
 	);
 	for ( let i = 0; i < tablists.length; i++ ) {
 		new TabsAutomatic( tablists[ i ] );
+	}
+
+	// Initialize scroll arrows for tabs
+	const tabsContainers = document.querySelectorAll(
+		'.wp-block-wpcomsp-tabs .tabs-container'
+	);
+	for ( let i = 0; i < tabsContainers.length; i++ ) {
+		new TabsScrollHandler( tabsContainers[ i ] );
 	}
 } );


### PR DESCRIPTION
When the screen is very narrow and contains a long list of tab buttons, the Tabs component cannot display all of them. This update improves the Tabs component by incorporating an arrow button that lets users see the remaining buttons.


https://github.com/user-attachments/assets/6d8c3d0e-2c7d-4668-9e20-593ec5383ac2

Context: In the one theme, we need the tab to display arrow keys when the tab cannot fit all buttons. We intend to incorporate this requirement into the Tabs block, as the theme relies on this block.

<img width="345" height="301" alt="Screenshot 2025-09-28 at 1 00 40 PM" src="https://github.com/user-attachments/assets/7b87c26d-4bd4-4827-9df1-ec3e84d9a8a4" />


MEkXtfiUhDZWQNmXDBT9oq-fi-10445_19429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds horizontal scrolling for tab lists with left/right arrow controls, smooth scrolling, keyboard support, dynamic arrow visibility on resize, and translated ARIA labels.

- Style
  - New responsive tab container and clipped tablist wrapper; hides native scrollbars, refines tab sizing/text for mobile, and hides editor arrows to reduce visual clutter.

- Refactor
  - Restructured tab markup to include scroll controls and a dedicated wrapper for improved UX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->