### PR TITLE
Updated npm build command to prevent errors when running the make-release action

### DIFF
--- a/jp-related-posts-query-loop/jp-related-posts-query-loop.php
+++ b/jp-related-posts-query-loop/jp-related-posts-query-loop.php
@@ -154,7 +154,13 @@ function a8csp_jrpql_get_related_posts_args( array $query_args ): array {
 		 * @var Jetpack_RelatedPosts_Raw $posts
 		 */
 		$posts = Jetpack_RelatedPosts::init_raw();
-		$posts = $posts->set_query_name( 'a8csp_jrpql_related_posts' )->get_for_post_id( $post_id, array( 'size' => $posts_per_page, 'post_type' => $posts_type ) );
+		$posts = $posts->set_query_name( 'a8csp_jrpql_related_posts' )->get_for_post_id(
+			$post_id,
+			array(
+				'size'      => $posts_per_page,
+				'post_type' => $posts_type,
+			)
+		);
 
 		$post_ids = wp_list_pluck( $posts, 'id' );
 		$post_ids = array_filter(

--- a/jp-related-posts-query-loop/jp-related-posts-query-loop.php
+++ b/jp-related-posts-query-loop/jp-related-posts-query-loop.php
@@ -9,8 +9,8 @@
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       a8csp-jprpql
- * Requires at least: 6.6
- * Tested up to:      6.8.3
+ * Requires at least: 6.7
+ * Tested up to:      6.9.0
  * Requires PHP:      7.4
  *
  * @package           a8csp

--- a/jp-related-posts-query-loop/package-lock.json
+++ b/jp-related-posts-query-loop/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "cover-scroll-bg-transition",
-	"version": "0.1.3",
+	"name": "jp-related-posts-query-loop",
+	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "cover-scroll-bg-transition",
-			"version": "0.1.3",
+			"name": "jp-related-posts-query-loop",
+			"version": "0.1.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/browserslist-config": "^6.29.0",

--- a/jp-related-posts-query-loop/package.json
+++ b/jp-related-posts-query-loop/package.json
@@ -5,7 +5,7 @@
 	"author": "WordPress Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"scripts": {
-		"build": "wp-scripts build src --output-path=build",
+		"build": "echo 'No js build step necessary.'",
 		"format:js": "wp-scripts format",
 		"format:styles": "wp-scripts lint-style --fix",
 		"lint:styles": "wp-scripts lint-style",


### PR DESCRIPTION
Added 'noop' npm build script to fix errors when building the releases since this plugin does not have js files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WordPress minimum version requirement to 6.7 and validated compatibility up to 6.9.0
  * Removed unnecessary build step from build configuration

* **Style**
  * Improved code formatting with named parameters in function calls

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->