### PR TITLE
[Dynamic Table of Contents]: Add filter for heading selectors customization

### DIFF
--- a/dynamic-table-of-contents/CHANGELOG.md
+++ b/dynamic-table-of-contents/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 0.2.0 - 2026-04-27
+
+### Added
+
+- New `a8csp_dynamic_table_of_contents_heading_selectors` filter to customize which headings appear in the rendered table of contents. The filter receives the default selectors, the block attributes, and the block object, and must return an array of selectors that the view script will query against.

--- a/dynamic-table-of-contents/dynamic-table-of-contents.php
+++ b/dynamic-table-of-contents/dynamic-table-of-contents.php
@@ -4,7 +4,7 @@
  * Description:       Creates a table of contents that's dynamically (PHP) rendered.
  * Requires at least: 6.1
  * Requires PHP:      8.0
- * Version:           0.1.9
+ * Version:           0.2.0
  * Author:            WordPress Special Projects Team
  * Author URI:        https://wpspecialprojects.wordpress.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/dynamic-table-of-contents/

--- a/dynamic-table-of-contents/package.json
+++ b/dynamic-table-of-contents/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dynamic-table-of-contents",
-    "version": "0.1.9",
+    "version": "0.2.0",
     "description": "Creates a table of contents that's dynamically (PHP) rendered.",
     "author": "The WordPress Contributors",
     "license": "GPL-2.0-or-later",

--- a/dynamic-table-of-contents/readme.txt
+++ b/dynamic-table-of-contents/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      The WordPress Contributors
 Tags:              block
 Tested up to:      6.1
-Stable tag:        0.1.0
+Stable tag:        0.2.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -43,7 +43,50 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 (or jpg, jpeg, gif).
 2. This is the second screen shot
 
+== Filters ==
+
+= `a8csp_dynamic_table_of_contents_heading_selectors` =
+
+Filters the CSS selectors used by the view script to collect headings for the table of contents.
+
+**Parameters**
+
+* `string[] $default_heading_selectors` - Array of selectors for table of contents headings.
+* `array    $attributes`                - Block attributes.
+* `WP_Block $block`                     - The block object.
+
+**Return**
+
+An array of selectors.
+
+**Example - limit the TOC to H2 headings only**
+
+`
+add_filter(
+    'a8csp_dynamic_table_of_contents_heading_selectors',
+    static function ( array $heading_selectors ): array {
+        return array( '.wp-block-post-content h2' );
+    }
+);
+`
+
+**Example - drop H1 from the TOC, keep everything else**
+
+`
+add_filter(
+    'a8csp_dynamic_table_of_contents_heading_selectors',
+    static function ( array $heading_selectors ): array {
+        return array_values(
+            array_diff( $heading_selectors, array( '.wp-block-post-content h1' ) )
+        );
+    }
+);
+`
+
 == Changelog ==
+
+= 0.2.0 =
+* Add `a8csp_dynamic_table_of_contents_heading_selectors` filter to customize which headings are listed in the TOC.
 
 = 0.1.0 =
 * Release

--- a/dynamic-table-of-contents/src/block.json
+++ b/dynamic-table-of-contents/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "wpcomsp/dynamic-table-of-contents",
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"title": "Dynamic Table of Contents",
 	"category": "design",
 	"description": "Creates a table of contents that's dynamically (PHP) rendered.",

--- a/dynamic-table-of-contents/src/render.php
+++ b/dynamic-table-of-contents/src/render.php
@@ -20,6 +20,40 @@ wp_enqueue_script(
 	$asset_deps['version'],
 	true
 );
+
+$default_heading_selectors = array(
+	'.wp-block-post-content h1',
+	'.wp-block-post-content h2',
+	'.wp-block-post-content h3',
+	'.wp-block-post-content h4',
+	'.wp-block-post-content h5',
+	'.wp-block-post-content h6',
+);
+
+/**
+ * Filters the selectors used by the view script to collect headings for the table of contents.
+ *
+ * @since 0.2.0
+ *
+ * @param string[] $default_heading_selectors Array of selectors for table of contents headings.
+ * @param array    $attributes                Block attributes.
+ * @param WP_Block $block                     The block object.
+ */
+$heading_selectors = apply_filters(
+	'a8csp_dynamic_table_of_contents_heading_selectors',
+	$default_heading_selectors,
+	$attributes,
+	$block
+);
+
+wp_add_inline_script(
+	'wpcomsp-dynamic-table-of-contents-view',
+	sprintf(
+		'window.wpcomspDynamicTOC=window.wpcomspDynamicTOC||{};window.wpcomspDynamicTOC.headingSelector=%s;',
+		wp_json_encode( implode( ', ', $heading_selectors ) )
+	),
+	'before'
+);
 ?>
 
 <div <?php echo wp_kses_post( get_block_wrapper_attributes() ); ?>>

--- a/dynamic-table-of-contents/src/render.php
+++ b/dynamic-table-of-contents/src/render.php
@@ -49,7 +49,7 @@ $heading_selectors = apply_filters(
 wp_add_inline_script(
 	'wpcomsp-dynamic-table-of-contents-view',
 	sprintf(
-		'window.wpcomspDynamicTOC=window.wpcomspDynamicTOC||{};window.wpcomspDynamicTOC.headingSelector=%s;',
+		'window.wpcomspDynamicTOC=window.wpcomspDynamicTOC||{};window.wpcomspDynamicTOC.headingSelectors=%s;',
 		wp_json_encode( implode( ', ', $heading_selectors ) )
 	),
 	'before'

--- a/dynamic-table-of-contents/src/view.js
+++ b/dynamic-table-of-contents/src/view.js
@@ -1,4 +1,6 @@
-const $headings = document.querySelectorAll('.wp-block-post-content h1, .wp-block-post-content h2, .wp-block-post-content h3, .wp-block-post-content h4, .wp-block-post-content h5, .wp-block-post-content h6');
+const $defaultHeadingSelector = '.wp-block-post-content h1, .wp-block-post-content h2, .wp-block-post-content h3, .wp-block-post-content h4, .wp-block-post-content h5, .wp-block-post-content h6';
+const $headingSelector = (window.wpcomspDynamicTOC && window.wpcomspDynamicTOC.headingSelector) || $defaultHeadingSelector;
+const $headings = document.querySelectorAll($headingSelector);
 const $headingList = document.querySelector('.wp-block-wpcomsp-dynamic-table-of-contents ul');
 
 // This is the observer that will be used to highlight the current heading.

--- a/dynamic-table-of-contents/src/view.js
+++ b/dynamic-table-of-contents/src/view.js
@@ -1,6 +1,6 @@
-const $defaultHeadingSelector = '.wp-block-post-content h1, .wp-block-post-content h2, .wp-block-post-content h3, .wp-block-post-content h4, .wp-block-post-content h5, .wp-block-post-content h6';
-const $headingSelector = (window.wpcomspDynamicTOC && window.wpcomspDynamicTOC.headingSelector) || $defaultHeadingSelector;
-const $headings = document.querySelectorAll($headingSelector);
+const $defaultHeadingSelectors = '.wp-block-post-content h1, .wp-block-post-content h2, .wp-block-post-content h3, .wp-block-post-content h4, .wp-block-post-content h5, .wp-block-post-content h6';
+const $headingSelectors = (window.wpcomspDynamicTOC && window.wpcomspDynamicTOC.headingSelectors) || $defaultHeadingSelectors;
+const $headings = document.querySelectorAll($headingSelectors);
 const $headingList = document.querySelector('.wp-block-wpcomsp-dynamic-table-of-contents ul');
 
 // This is the observer that will be used to highlight the current heading.


### PR DESCRIPTION
Added PHP filter hook `a8csp_dynamic_table_of_contents_heading_selectors` support for table-of-contents heading selectors.

issue #153 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new filter allowing developers to customize CSS selectors used to identify headings for the table of contents. Supports restricting specific heading levels or excluding certain headings from TOC generation.

* **Documentation**
  * Added comprehensive filter documentation with parameter descriptions and practical examples demonstrating how to customize heading selector behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->