### PR TITLE
Updates to the TOC block based on requirements from earth species project.

### DIFF
--- a/dynamic-table-of-contents/dynamic-table-of-contents.php
+++ b/dynamic-table-of-contents/dynamic-table-of-contents.php
@@ -4,7 +4,7 @@
  * Description:       Creates a table of contents that's dynamically (PHP) rendered.
  * Requires at least: 6.1
  * Requires PHP:      8.0
- * Version:           0.2.0
+ * Version:           0.3.0
  * Author:            WordPress Special Projects Team
  * Author URI:        https://wpspecialprojects.wordpress.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/dynamic-table-of-contents/
@@ -80,14 +80,16 @@ function wpcomsp_dynamic_table_of_contents_block_render( $block_content, $block 
 	$processor = new WP_HTML_Tag_Processor( $block_content );
 	$processor->next_tag();
 
-	// If the heading already has an ID, don't add one.
-	if ( null !== $processor->get_attribute( 'ID' ) ) {
-		return $block_content;
+	if ( isset( $block['attrs']['customTitle'] ) && ! empty( $block['attrs']['customTitle'] ) ) {
+		$processor->set_attribute( 'customtitle', $block['attrs']['customTitle'] );
 	}
 
-	// If the heading doesn't have an ID, add one.
-	$content = wp_strip_all_tags( $block_content );
-	$processor->set_attribute( 'ID', esc_attr( sanitize_title( $content ) ) );
+	// If the heading already has an ID, don't add one.
+	if ( null === $processor->get_attribute( 'ID' ) ) {
+		// If the heading doesn't have an ID, add one.
+		$content = wp_strip_all_tags( $block_content );
+		$processor->set_attribute( 'id', esc_attr( sanitize_title( $content ) ) );
+	}
 
 	return $processor->get_updated_html();
 }

--- a/dynamic-table-of-contents/readme.txt
+++ b/dynamic-table-of-contents/readme.txt
@@ -43,6 +43,15 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 (or jpg, jpeg, gif).
 2. This is the second screen shot
 
+== Settings ==
+
+There are 3 settings for this block:
+
+Block Title: The title displayed for the table of contents block
+Heading Selectors: Which headings should be displayed in the table of contents block. This can be overwritten by the filter below.
+Custom Titles: Whether to allow the user to enter custom titles for each heading instead of using the text content.
+ - If this is enabled, the user can add a custom title to the input field. The data is saved in the heading attributes block.
+
 == Filters ==
 
 = `a8csp_dynamic_table_of_contents_heading_selectors` =
@@ -83,7 +92,27 @@ add_filter(
 );
 `
 
+= `wpcomsp_dynamic_table_of_contents_allow_custom_titles` = 
+
+Filters the value used by the view script to determine if custom titles are allowed for the table of contents.
+
+** Example - remove any custom titles from the TOC block **
+
+`
+add_filter(
+    'wpcomsp_dynamic_table_of_contents_allow_custom_titles',
+    static function ( string $heading_selectors ): string {
+        return 'false';
+    }
+);
+`
+
 == Changelog ==
+
+= 0.3.0 =
+* Added the ability to choose which heading levels are displayed in the toc block in the gutenberg editor
+* Added the ability to choose a different title than the one displayed in the content for the TOC list item
+* Added the `wpcomsp_dynamic_table_of_contents_allow_custom_titles` filter to override user preference.
 
 = 0.2.0 =
 * Add `a8csp_dynamic_table_of_contents_heading_selectors` filter to customize which headings are listed in the TOC.

--- a/dynamic-table-of-contents/src/block.json
+++ b/dynamic-table-of-contents/src/block.json
@@ -27,13 +27,19 @@
 			"color": true
 		}
 	},
-	"usesContext": [
-		"postId"
-	],
+	"usesContext": [ "postId" ],
 	"attributes": {
 		"title": {
 			"type": "string",
 			"default": "Table of Contents"
+		},
+		"headingLevels": {
+			"type": "array",
+			"default": [ 1, 2, 3 ]
+		},
+		"customTitles": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"textdomain": "dynamic-table-of-contents",

--- a/dynamic-table-of-contents/src/components/list-item.js
+++ b/dynamic-table-of-contents/src/components/list-item.js
@@ -1,0 +1,81 @@
+import { __ } from '@wordpress/i18n';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { Button, TextControl } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+
+const ListItem = ( { title, id, customTitles, customTitle } ) => {
+	const [ isEditing, setIsEditing ] = useState( false );
+	const [ updatedText, setUpdatedText ] = useState( title );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	return (
+		<li key={ id }>
+			{ isEditing ? (
+				<>
+					<TextControl
+						__next40pxDefaultSize
+						value={ updatedText }
+						onChange={ ( value ) => {
+							setUpdatedText( value );
+						} }
+					/>
+					<div
+						style={ {
+							display: 'flex',
+							gap: '0.5rem',
+							marginTop: '0.5rem',
+						} }
+					>
+						<Button
+							isPrimary
+							onClick={ () => {
+								updateBlockAttributes( id, {
+									customTitle: updatedText,
+								} );
+							} }
+						>
+							{ __( 'Update', 'dynamic-table-of-contents' ) }
+						</Button>
+						<Button
+							isSecondary
+							onClick={ () => {
+								updateBlockAttributes( id, {
+									customTitle: null,
+								} );
+							} }
+						>
+							{ __( 'Reset', 'dynamic-table-of-contents' ) }
+						</Button>
+						<Button
+							isLink
+							onClick={ () => {
+								setIsEditing( ! isEditing );
+							} }
+						>
+							{ __( 'Close', 'dynamic-table-of-contents' ) }
+						</Button>
+					</div>
+				</>
+			) : (
+				<a href={ `#block-${ id }` }>
+					{ ( customTitles && customTitle ) || title }
+				</a>
+			) }
+			{ ! isEditing && customTitles && (
+				<Button
+					isLink
+					className="edit-heading-title"
+					onClick={ () => {
+						setIsEditing( ! isEditing );
+					} }
+					style={ { marginLeft: '0.5ch' } }
+				>
+					{ __( 'Edit Title', 'dynamic-table-of-contents' ) }
+				</Button>
+			) }
+		</li>
+	);
+};
+
+export default ListItem;

--- a/dynamic-table-of-contents/src/edit.js
+++ b/dynamic-table-of-contents/src/edit.js
@@ -1,35 +1,188 @@
 import { __ } from '@wordpress/i18n';
-import { useBlockProps, RichText } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	RichText,
+	InspectorControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+
+import {
+	Button,
+	ButtonGroup,
+	PanelBody,
+	ToggleControl,
+	PanelRow,
+} from '@wordpress/components';
+
+import { useSelect } from '@wordpress/data';
+
+import { useMemo } from '@wordpress/element';
+
+/* Internal dependencies */
+import ListItem from './components/list-item';
 
 /**
  * The edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.
  *
+ * @param {Object}   props               Props passed to the block, including attributes and setAttributes function.
+ * @param {Object}   props.attributes    The current attributes of the block.
+ * @param {Function} props.setAttributes Function to update the block's attributes.
+ *
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
  *
  * @return {Element} Element to render.
  */
-export default function Edit({ attributes, setAttributes }) {
+export default function Edit( { attributes, setAttributes } ) {
+	const { headingLevels, title, customTitles } = attributes;
+
+	const headings = [ 1, 2, 3, 4, 5, 6 ];
+
+	const allBlocks = useSelect( ( select ) => {
+		const { getClientIdsWithDescendants, getBlock } =
+			select( blockEditorStore );
+		return getClientIdsWithDescendants().map( ( clientId ) =>
+			getBlock( clientId )
+		);
+	}, [] );
+
+	const headingBlocks = useMemo( () => {
+		const stripHTML = ( html ) => {
+			// eslint-disable-next-line no-undef
+			const doc = new DOMParser().parseFromString( html, 'text/html' );
+			return doc.body.textContent ?? '';
+		};
+
+		const getHeadingContent = ( block ) => {
+			if ( block.attributes.content.originalHTML ) {
+				return stripHTML( block.attributes.content.originalHTML );
+			}
+			return stripHTML( block.attributes.content );
+		};
+
+		return allBlocks
+			.filter(
+				( block ) =>
+					block?.name === 'core/heading' &&
+					headingLevels.includes( block.attributes.level )
+			)
+			.map( ( block ) => {
+				// Add plain text content to each heading block
+				return {
+					...block,
+					plainTextContent: getHeadingContent( block ),
+				};
+			} );
+	}, [ allBlocks, headingLevels ] );
+
+	const updateHeadingLevels = ( level ) => {
+		const newHeadingLevels = headingLevels.includes( level )
+			? headingLevels.filter( ( l ) => l !== level )
+			: [ ...headingLevels, level ];
+		setAttributes( { headingLevels: newHeadingLevels } );
+	};
+
 	return (
-		<div {...useBlockProps()}>
-			<RichText
-				tagName="h2"
-				placeholder={__('Table of Contents Title', 'dynamic-table-of-contents')}
-				value={attributes.title}
-				onChange={(title) => setAttributes({ title })}
-				className="table-of-contents-title"
-			/>
-			<ul className="table-of-contents-list">
-				<li className="table-of-contents-list-item">
-					<a href="#" className='active'>This is an example.</a>
-				</li>
-				<li className="table-of-contents-list-item">
-					<a href="#">Of the block appearance.</a>
-				</li>
-				<li className="table-of-contents-list-item">
-					<a href="#">When used in your post.</a>
-				</li>
-			</ul>
-		</div>
+		<>
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Settings', 'dynamic-table-of-contents' ) }
+				>
+					<h3>
+						{ __(
+							'Headings to include',
+							'dynamic-table-of-contents'
+						) }
+					</h3>
+					<PanelRow>
+						<ButtonGroup>
+							{ headings.map( ( level ) => (
+								<Button
+									key={ level }
+									variant={
+										headingLevels.includes( level )
+											? 'primary'
+											: 'secondary'
+									}
+									onClick={ () => {
+										updateHeadingLevels( level );
+									} }
+								>
+									H{ level }
+								</Button>
+							) ) }
+						</ButtonGroup>
+					</PanelRow>
+					<h3 style={ { marginTop: '2em' } }>
+						{ __( 'Custom Titles', 'dynamic-table-of-contents' ) }
+					</h3>
+					<PanelRow>
+						<ToggleControl
+							label={ __(
+								'Enable Custom titles',
+								'dynamic-table-of-contents'
+							) }
+							help={
+								customTitles
+									? __(
+											'Custom titles enabled.',
+											'dynamic-table-of-contents'
+									  )
+									: __(
+											'Custom titles disabled.',
+											'dynamic-table-of-contents'
+									  )
+							}
+							checked={ customTitles }
+							onChange={ ( newValue ) => {
+								setAttributes( { customTitles: newValue } );
+							} }
+						/>
+					</PanelRow>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...useBlockProps() }>
+				<RichText
+					tagName="h2"
+					placeholder={ __(
+						'Table of Contents Title',
+						'dynamic-table-of-contents'
+					) }
+					value={ title }
+					onChange={ ( newTitle ) =>
+						setAttributes( { title: newTitle } )
+					}
+					className="table-of-contents-title"
+				/>
+				<ul className="table-of-contents-list">
+					{ headingBlocks.length > 0 ? (
+						headingBlocks.map( ( block ) => {
+							return (
+								<ListItem
+									key={ block.clientId }
+									id={ block.clientId }
+									title={
+										block.plainTextContent ||
+										__(
+											'Untitled Heading',
+											'dynamic-table-of-contents'
+										)
+									}
+									customTitles={ customTitles }
+									customTitle={ block.attributes.customTitle }
+								/>
+							);
+						} )
+					) : (
+						<li>
+							{ __(
+								'No headings found. Please add some headings to your content.',
+								'dynamic-table-of-contents'
+							) }
+						</li>
+					) }
+				</ul>
+			</div>
+		</>
 	);
 }

--- a/dynamic-table-of-contents/src/filters.js
+++ b/dynamic-table-of-contents/src/filters.js
@@ -1,0 +1,29 @@
+export const addCustomTitleAttribute = ( settings, name ) => {
+	if ( name !== 'core/heading' ) {
+		return settings;
+	}
+	settings.attributes = {
+		...settings.attributes,
+		customTitle: {
+			type: 'string',
+		},
+	};
+	return settings;
+};
+
+export const saveCustomTitleAttribute = ( extraProps, blockType, attr ) => {
+	if ( blockType.name !== 'core/heading' ) {
+		return extraProps;
+	}
+
+	if ( ! attr?.customTitle ) {
+		return extraProps;
+	}
+
+	const updatedProps = {
+		...extraProps,
+		customTitle: attr.customTitle,
+	};
+
+	return updatedProps;
+};

--- a/dynamic-table-of-contents/src/index.js
+++ b/dynamic-table-of-contents/src/index.js
@@ -4,6 +4,7 @@
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
@@ -19,6 +20,7 @@ import './style.scss';
  */
 import Edit from './edit';
 import metadata from './block.json';
+import { addCustomTitleAttribute, saveCustomTitleAttribute } from './filters';
 
 const icon = (
 	<svg
@@ -30,8 +32,8 @@ const icon = (
 		focusable="false"
 	>
 		<path
-			fill-rule="evenodd"
-			clip-rule="evenodd"
+			fillRule="evenodd"
+			clipRule="evenodd"
 			d="M20 9.484h-8.889v-1.5H20v1.5Zm0 7h-4.889v-1.5H20v1.5Zm-14 .032a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm0 1a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z"
 		></path>
 		<path d="M13 15.516a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM8 8.484a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z"></path>
@@ -50,3 +52,15 @@ registerBlockType( metadata.name, {
 
 	icon,
 } );
+
+addFilter(
+	'blocks.registerBlockType',
+	'dynamic-table-of-contents/heading-block-attr',
+	addCustomTitleAttribute
+);
+
+addFilter(
+	'blocks.getSaveContent.extraProps',
+	'dynamic-table-of-contents/add-heading-block-attr',
+	saveCustomTitleAttribute
+);

--- a/dynamic-table-of-contents/src/render.php
+++ b/dynamic-table-of-contents/src/render.php
@@ -21,13 +21,11 @@ wp_enqueue_script(
 	true
 );
 
-$default_heading_selectors = array(
-	'.wp-block-post-content h1',
-	'.wp-block-post-content h2',
-	'.wp-block-post-content h3',
-	'.wp-block-post-content h4',
-	'.wp-block-post-content h5',
-	'.wp-block-post-content h6',
+$default_heading_selectors = array_map(
+	function ( $level ) {
+		return sprintf( '.wp-block-post-content h%d', $level );
+	},
+	$attributes['headingLevels'] ? $attributes['headingLevels'] : range( 1, 6 )
 );
 
 /**
@@ -46,6 +44,22 @@ $heading_selectors = apply_filters(
 	$block
 );
 
+/**
+ * Filters the value used by the view script to determine if custom titles are allowed for the table of contents.
+ *
+ * @since 0.3.0
+ *
+ * @param string[] $default_heading_selectors Array of selectors for table of contents headings.
+ * @param array    $attributes                Block attributes.
+ * @param WP_Block $block                     The block object.
+ */
+$allow_custom_titles = apply_filters(
+	'wpcomsp_dynamic_table_of_contents_allow_custom_titles',
+	$attributes['customTitles'] ? 'true' : 'false',
+	$attributes,
+	$block
+);
+
 wp_add_inline_script(
 	'wpcomsp-dynamic-table-of-contents-view',
 	sprintf(
@@ -56,7 +70,7 @@ wp_add_inline_script(
 );
 ?>
 
-<div <?php echo wp_kses_post( get_block_wrapper_attributes() ); ?>>
+<div <?php echo wp_kses_post( get_block_wrapper_attributes( array( 'data-custom-titles' => $allow_custom_titles ) ) ); ?>>
 	<?php
 	$block_title = $attributes['title'] ?? '';
 	$block_title = apply_filters( 'wpcomsp_dynamic_table_of_contents_block_title', $block_title, $attributes );

--- a/dynamic-table-of-contents/src/view.js
+++ b/dynamic-table-of-contents/src/view.js
@@ -1,52 +1,70 @@
-const $defaultHeadingSelectors = '.wp-block-post-content h1, .wp-block-post-content h2, .wp-block-post-content h3, .wp-block-post-content h4, .wp-block-post-content h5, .wp-block-post-content h6';
-const $headingSelectors = (window.wpcomspDynamicTOC && window.wpcomspDynamicTOC.headingSelectors) || $defaultHeadingSelectors;
-const $headings = document.querySelectorAll($headingSelectors);
-const $headingList = document.querySelector('.wp-block-wpcomsp-dynamic-table-of-contents ul');
+const $defaultHeadingSelectors =
+	'.wp-block-post-content h1, .wp-block-post-content h2, .wp-block-post-content h3, .wp-block-post-content h4, .wp-block-post-content h5, .wp-block-post-content h6';
+const $headingSelectors =
+	( window.wpcomspDynamicTOC && window.wpcomspDynamicTOC.headingSelectors ) ||
+	$defaultHeadingSelectors;
+const $headings = document.querySelectorAll( $headingSelectors );
+const $headingList = document.querySelector(
+	'.wp-block-wpcomsp-dynamic-table-of-contents ul'
+);
+const $allowCustomTitles =
+	document
+		.querySelector( '.wp-block-wpcomsp-dynamic-table-of-contents' )
+		.getAttribute( 'data-custom-titles' ) === 'true';
 
 // This is the observer that will be used to highlight the current heading.
-const $observer = new IntersectionObserver((entries) => {
-	let $links = document.querySelectorAll('.wp-block-wpcomsp-dynamic-table-of-contents a');
+const $observer = new IntersectionObserver(
+	( entries ) => {
+		let $links = document.querySelectorAll(
+			'.wp-block-wpcomsp-dynamic-table-of-contents a'
+		);
 
-	entries.forEach((entry) => {
-		const $id = entry.target.id;
-		const $link = document.querySelector(`.wp-block-wpcomsp-dynamic-table-of-contents a[href="#${$id}"]`);
+		entries.forEach( ( entry ) => {
+			const $id = entry.target.id;
+			const $link = document.querySelector(
+				`.wp-block-wpcomsp-dynamic-table-of-contents a[href="#${ $id }"]`
+			);
 
-		if (entry.isIntersecting) {
-			$links.forEach((link) => {
-				link.classList.remove('active');
-			});
+			if ( entry.isIntersecting ) {
+				$links.forEach( ( link ) => {
+					link.classList.remove( 'active' );
+				} );
 
-			$link.classList.add('active');
-		}
-	});
-},
-{
-	rootMargin: '0px 0px -75% 0px',
-});
+				$link.classList.add( 'active' );
+			}
+		} );
+	},
+	{
+		rootMargin: '0px 0px -75% 0px',
+	}
+);
 
-$headings.forEach((heading, index) => {
+$headings.forEach( ( heading, index ) => {
 	const $id = heading.id;
 
-	if ($id.length) {
+	if ( $id.length ) {
 		// Create new elements.
-		const $latestListItem = document.createElement('li');
-		const $latestLink = document.createElement('a');
+		const $latestListItem = document.createElement( 'li' );
+		const $latestLink = document.createElement( 'a' );
+		const customTitle = heading.getAttribute( 'customtitle' );
 
 		// Add attributes to new elements.
-		$latestLink.href = `#${$id}`;
-		$latestLink.textContent = heading.textContent;
+		$latestLink.href = `#${ $id }`;
+		$latestLink.textContent =
+			$allowCustomTitles && customTitle
+				? customTitle
+				: heading.textContent;
 
 		// Setup the first element as active.
-		if (0 === index) {
-			$latestLink.classList.add('active');
+		if ( 0 === index ) {
+			$latestLink.classList.add( 'active' );
 		}
 
 		// Add new elements to the markup.
-		$latestListItem.appendChild($latestLink);
-		$headingList.appendChild($latestListItem);
+		$latestListItem.appendChild( $latestLink );
+		$headingList.appendChild( $latestListItem );
 
 		// Setup on scroll highlighting.
-		$observer.observe(heading);
+		$observer.observe( heading );
 	}
-
-});
+} );


### PR DESCRIPTION
- Add controls for the block editor to allow users to select the heading levels displayed
- Added controls for the block editor allowing the editor to change the name that appears in the TOC list item (for example a H2 might have the content "Hey there, I'm ____  the CEO of ACME" but the table of contents might have "Message from our CEO" 
- Added a filter controlled by the developer to allow or disallow the custom titles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added editor controls to select which heading levels (H1-H6) to include in the table of contents
  * Enabled custom title functionality allowing override of heading text displayed in the table of contents
  * Added toggle to enable/disable custom title editing in block settings

* **Documentation**
  * Added "Settings" section documenting table of contents configuration options and custom title functionality
  * Added documentation for the new filter enabling control over custom title behavior with usage examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/a8cteam51/special-projects-blocks-monorepo/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->