### PR TITLE
Updates to modal to allow support for videos and improve closing experience

### DIFF
--- a/modal/CHANGELOG.md
+++ b/modal/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 -   Add support for iFrames by rendering the modal content through `the_content` filter
 -   Stop media in a Modal from playing when the modal is closed
--   Improvements to the closing state of the modal, adding by adding a document event listener and also adding a click event to the modal top level container.
+-   Improvements to the closing state of the modal, by adding a document event listener and also adding a click event to the modal top level container.
 -   Minor updates to the CSS
 
 ## 0.1.2 (2025-10-21)

--- a/modal/CHANGELOG.md
+++ b/modal/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.3 (2026-05)
+
+-   Add support for iFrames by rendering the modal content through `the_content` filter
+-   Stop media in a Modal from playing when the modal is closed
+-   Improvements to the closing state of the modal, adding by adding a document event listener and also adding a click event to the modal top level container.
+-   Minor updates to the CSS
+
 ## 0.1.2 (2025-10-21)
 
 ### Fixed

--- a/modal/modal.php
+++ b/modal/modal.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Modal
  * Description:       A modal block that can be toggled open and closed.
- * Version:           0.1.2
+ * Version:           0.1.3
  * Requires at least: 6.6
  * Requires PHP:      7.2
  * Author:            WordPress Special Projects Team
@@ -207,7 +207,8 @@ function a8csp_modal_insert_modal_templates() {
 			aria-modal="true"
 			data-wp-interactive="a8csp/modal"
 			data-wp-class--is-open="state.isModalOpen"
-			data-wp-on--keydown="actions.handleModalKeydown"
+			data-wp-on-document--keydown="actions.handleModalKeydown"
+			data-wp-on--click="actions.handleModalClick"
 			data-wp-bind--aria-hidden="!state.isModalOpen"
 			data-wp-bind--inert="!state.isModalOpen"
 			data-wp-bind--aria-label="context.title"
@@ -254,7 +255,7 @@ function a8csp_modal_default_inner_content( $template ) {
 	?>
 	<div class="wp-block-a8csp-modal-container--inner">
 
-		<?php echo do_blocks( $template['content'] ); // phpcs:ignore WordPress.Security.EscapeOutput ?>
+		<?php echo apply_filters( 'the_content', $template['content'] ); // phpcs:ignore WordPress.Security.EscapeOutput ?>
 	</div>
 
 	<button

--- a/modal/src/style.scss
+++ b/modal/src/style.scss
@@ -34,14 +34,14 @@ body.modal-open {
 
 		svg {
 			path {
-				stroke: currentColor;
+				stroke: currentcolor;
 			}
 		}
 	}
 
 	.wp-block-a8csp-modal-container--inner {
-		max-height: 100%;
-		overflow-y: scroll;
+		max-height: 100vh;
+		overflow-y: auto;
 		width: 100%;
 	}
 }

--- a/modal/src/view.js
+++ b/modal/src/view.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { store, getContext, getElement } from '@wordpress/interactivity';
+import { store, getContext } from '@wordpress/interactivity';
 
 const { actions, state, helpers } = store( 'a8csp/modal', {
 	state: {
@@ -15,12 +15,18 @@ const { actions, state, helpers } = store( 'a8csp/modal', {
 		focusOpen() {
 			const { id } = getContext();
 			const modal = helpers.getModal( id );
-			const focusElements = [ ...modal.querySelectorAll(
-				'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"]'
-				) ].filter( element => ! element.hasAttribute( 'disabled' ) && ! element.getAttribute('aria-hidden') );
+			const focusElements = [
+				...modal.querySelectorAll(
+					'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"]'
+				),
+			].filter(
+				( element ) =>
+					! element.hasAttribute( 'disabled' ) &&
+					! element.getAttribute( 'aria-hidden' )
+			);
 			const focusElement = focusElements[ 0 ] || null;
 			const closeBtn = helpers.getCloseBtn( modal );
-	
+
 			if ( focusElement ) {
 				focusElement.focus();
 			} else {
@@ -41,6 +47,22 @@ const { actions, state, helpers } = store( 'a8csp/modal', {
 				modal.removeEventListener( 'transitionend', actions.focusOpen );
 			}
 		},
+		stopMediaElements() {
+			const { id } = getContext();
+			const modal = helpers.getModal( id );
+			const mediaElements = modal.querySelectorAll(
+				'iframe, video, audio'
+			);
+
+			if ( mediaElements.length === 0 ) {
+				return;
+			}
+
+			[ ...mediaElements ].forEach( ( element ) => {
+				// Resetting src unloads iframes and stops media playback.
+				element.src = element.src;
+			} );
+		},
 		closeModal() {
 			const { id } = getContext();
 			const modal = helpers.getModal( id );
@@ -49,15 +71,21 @@ const { actions, state, helpers } = store( 'a8csp/modal', {
 			state.selected = null;
 
 			actions.togglePageFocus( false );
+			actions.stopMediaElements();
 
 			// This is needed as the focus cannot be set until the modal is fully visible.
 			if ( helpers.hasTransition( modal ) ) {
-				modal.addEventListener( 'transitionend', actions.focusClose, false );
+				modal.addEventListener(
+					'transitionend',
+					actions.focusClose,
+					false
+				);
 			} else {
 				actions.focusClose();
 			}
 
 			body.classList.remove( 'modal-open' );
+			modal.classList.remove( 'is-open' );
 		},
 		openModal( event ) {
 			const { id } = getContext();
@@ -67,7 +95,10 @@ const { actions, state, helpers } = store( 'a8csp/modal', {
 			state.selected = id;
 
 			// Don't return focus to the clicked button if it is inside a modal.
-			if ( event.target.closest(".wp-block-a8csp-modal-container") === null ) {
+			if (
+				event.target.closest( '.wp-block-a8csp-modal-container' ) ===
+				null
+			) {
 				state.clickedButton = event.target.id;
 			}
 
@@ -75,18 +106,32 @@ const { actions, state, helpers } = store( 'a8csp/modal', {
 
 			// This is needed as the focus cannot be set until the modal is fully visible.
 			if ( helpers.hasTransition( modal ) ) {
-				modal.addEventListener( 'transitionend', actions.focusOpen, false );
+				modal.addEventListener(
+					'transitionend',
+					actions.focusOpen,
+					false
+				);
 			} else {
 				actions.focusOpen();
 			}
 
 			body.classList.add( 'modal-open' );
+			modal.classList.add( 'is-open' );
 		},
 		handleModalKeydown( event ) {
-			// If Escape close the menu.
-			if ( event?.key === 'Escape' ) {
+			if ( event?.key === 'Escape' && state.isModalOpen ) {
 				actions.closeModal();
 			}
+		},
+		handleModalClick( event ) {
+			const { id } = getContext();
+			const modalContainer = event.target.id.includes( id );
+
+			if ( ! modalContainer ) {
+				return;
+			}
+
+			actions.closeModal();
 		},
 		togglePageFocus( toggle ) {
 			const siteContainer = helpers.getSiteContainer();
@@ -109,12 +154,14 @@ const { actions, state, helpers } = store( 'a8csp/modal', {
 				return;
 			}
 
-			if ( 'wp-block-a8csp-modal' === event.target.className ) {
+			if ( event.target.className.includes( 'wp-block-a8csp-modal' ) ) {
 				return;
 			}
-			
+
 			const modal = helpers.getModal( id );
-			const modalInner = modal.querySelector( '.wp-block-a8csp-modal-container--inner' );
+			const modalInner = modal.querySelector(
+				'.wp-block-a8csp-modal-container--inner'
+			);
 
 			if ( ! modalInner.contains( event.target ) ) {
 				actions.closeModal();
@@ -129,19 +176,25 @@ const { actions, state, helpers } = store( 'a8csp/modal', {
 			return document.getElementById( id );
 		},
 		getSiteContainer: () => {
-			return document.getElementsByClassName( 'wp-site-blocks' ) ? document.getElementsByClassName( 'wp-site-blocks' )[ 0 ] : null;
+			return document.getElementsByClassName( 'wp-site-blocks' )
+				? document.getElementsByClassName( 'wp-site-blocks' )[ 0 ]
+				: null;
 		},
 		getSkipLink: () => {
-			return document.getElementsByClassName( 'skip-link' ) ? document.getElementsByClassName( 'skip-link' )[ 0 ] : null;
+			return document.getElementsByClassName( 'skip-link' )
+				? document.getElementsByClassName( 'skip-link' )[ 0 ]
+				: null;
 		},
 		getCloseBtn: ( modal ) => {
 			return modal.getElementsByClassName( 'close-modal' )[ 0 ];
 		},
 		hasTransition( element ) {
-			return parseFloat( getComputedStyle(element)['transitionDuration'] );
+			return parseFloat(
+				getComputedStyle( element )[ 'transitionDuration' ]
+			);
 		},
 		getBody() {
 			return document.body;
-		}
+		},
 	},
 } );

--- a/modal/src/view.js
+++ b/modal/src/view.js
@@ -17,7 +17,7 @@ const { actions, state, helpers } = store( 'a8csp/modal', {
 			const modal = helpers.getModal( id );
 			const focusElements = [
 				...modal.querySelectorAll(
-					'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"]'
+					'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
 				),
 			].filter(
 				( element ) =>
@@ -125,9 +125,8 @@ const { actions, state, helpers } = store( 'a8csp/modal', {
 		},
 		handleModalClick( event ) {
 			const { id } = getContext();
-			const modalContainer = event.target.id.includes( id );
 
-			if ( ! modalContainer ) {
+			if ( event.target.id !== id ) {
 				return;
 			}
 
@@ -154,7 +153,7 @@ const { actions, state, helpers } = store( 'a8csp/modal', {
 				return;
 			}
 
-			if ( event.target.className.includes( 'wp-block-a8csp-modal' ) ) {
+			if ( event.target.classList.contains( 'wp-block-a8csp-modal' ) ) {
 				return;
 			}
 


### PR DESCRIPTION
-   Add support for iFrames by rendering the modal content through `the_content` filter
-   Stop media in a Modal from playing when the modal is closed
-   Improvements to the closing state of the modal, adding by adding a document event listener and also adding a click event to the modal top level container.
-   Minor updates to the CSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iframe support for richer modal content rendering
  * Media (video, audio, iframe) playback now stops when a modal closes

* **Bug Fixes**
  * Improved modal closing behavior with refined click and keyboard handling
  * Better focus restoration after modal open/close transitions

* **Style**
  * Adjusted modal sizing and scrolling for improved viewport behavior
  * Minor CSS tweaks for icon rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->