### PR TITLE
Add CONTRIBUTING, issue/PR templates, and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners for the Special Projects Blocks Monorepo.
+# https://docs.github.com/en/repositories/managing-your-repositories-permissions/about-code-owners
+#
+# The internal devs team owns everything and is requested for review on every PR.
+* @a8cteam51/team51-internal-devs

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: 🐛 Bug report
+description: Report a problem with an existing block or plugin.
+title: "<Block>: <short description of the bug>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Please title it like the examples in this repo, e.g.
+        `Mega Menu Block: Front-end rendering does not match editor preview`.
+  - type: dropdown
+    id: plugin
+    attributes:
+      label: Affected plugin
+      description: Which top-level plugin directory does this affect?
+      options:
+        - bp-breadcrumbs
+        - bp-groups
+        - bp-members
+        - counter
+        - cover-bg-crossfade
+        - dynamic-table-of-contents
+        - exclude-duplicates-from-query-loops
+        - featured-image-captions
+        - featured-video
+        - flowing-column
+        - jp-related-posts-query-loop
+        - light-dark-toggle
+        - mega-menu
+        - modal
+        - override-post-links
+        - reactions
+        - scroll-progress-bar
+        - scroll-to-top
+        - sibling-pages-list
+        - stretchy-type
+        - table-plus
+        - tabs
+        - videopress-download
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+    validations:
+      required: true
+  - type: input
+    id: wp-version
+    attributes:
+      label: WordPress version
+      placeholder: "e.g. 6.8"
+  - type: input
+    id: theme
+    attributes:
+      label: Theme
+      placeholder: "e.g. Twenty Twenty-Five"
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP version
+      placeholder: "e.g. 8.2"
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / screencast
+      description: Editor and front-end, where relevant.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true
+        - label: I reproduced this in the latest `twenty-*` theme (to rule out project styling).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 Documentation & process (wiki)
+    url: https://github.com/a8cteam51/special-projects-blocks-monorepo/wiki
+    about: Creating, re-using, and updating blocks, plus the process for site build engineers.
+  - name: 🧱 Contributing guide
+    url: https://github.com/a8cteam51/special-projects-blocks-monorepo/blob/trunk/CONTRIBUTING.md
+    about: How to set up, build, and submit changes.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,69 @@
+name: ✨ Feature request / enhancement
+description: Suggest an improvement to an existing block or plugin.
+title: "<Block>: <short description of the enhancement>"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For a brand-new block, use the **New block proposal** template instead.
+        Remember: enhancements must benefit **all** sites using the block, not just one
+        project. Project-specific needs are usually better met with filters, block
+        styles, or variations — see the
+        [re-using a block guide](https://github.com/a8cteam51/special-projects-blocks-monorepo/wiki/Re%E2%80%90Using-an-Existing-Block-in-Your-Project).
+  - type: dropdown
+    id: plugin
+    attributes:
+      label: Affected plugin
+      options:
+        - bp-breadcrumbs
+        - bp-groups
+        - bp-members
+        - counter
+        - cover-bg-crossfade
+        - dynamic-table-of-contents
+        - exclude-duplicates-from-query-loops
+        - featured-image-captions
+        - featured-video
+        - flowing-column
+        - jp-related-posts-query-loop
+        - light-dark-toggle
+        - mega-menu
+        - modal
+        - override-post-links
+        - reactions
+        - scroll-progress-bar
+        - scroll-to-top
+        - sibling-pages-list
+        - stretchy-type
+        - table-plus
+        - tabs
+        - videopress-download
+        - General / tooling
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What's the user problem or limitation this solves?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Could a filter, block style, variation, or pattern achieve this without a code change to the block?
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: This change benefits all sites using the block, not just one project.
+          required: true

--- a/.github/ISSUE_TEMPLATE/new_block_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/new_block_proposal.yml
@@ -1,0 +1,66 @@
+name: 🧱 New block proposal
+description: Propose a new block for the monorepo (engineering-lead sign-off required).
+title: "New block: <block name>"
+labels: ["blocks", "idea"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The gold standard is **not** creating a new block — every block is permanent
+        maintenance. Please confirm you've ruled out the alternatives below before
+        proposing. An engineering lead must approve before development starts.
+  - type: checkboxes
+    id: gate
+    attributes:
+      label: Have you ruled out the alternatives?
+      description: A new block should be the last resort. See [How to extend a WordPress block](https://developer.wordpress.org/news/2024/08/15/how-to-extend-a-wordpress-block/).
+      options:
+        - label: This can't be built with a **pattern** of existing blocks.
+          required: true
+        - label: This can't be built with the **Block Bindings API**.
+          required: true
+        - label: This can't be built with the **Interactivity API** on an existing block.
+          required: true
+        - label: This can't be built by **extending/restyling a core block** (block styles, variations, filters).
+          required: true
+  - type: textarea
+    id: reuse-check
+    attributes:
+      label: Existing-block check
+      description: Which existing monorepo plugins did you check, and why don't they fit? (See the inventory in the README.)
+    validations:
+      required: true
+  - type: input
+    id: block-name
+    attributes:
+      label: Proposed block name
+      description: Use the `a8csp` namespace.
+      placeholder: "a8csp/<block-slug>"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What does the block do? Be verbose — this informs the block.json description and automated tooling.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: wireframe
+    attributes:
+      label: Wireframe / design / screenshot
+      description: Figma link or image showing the intended block.
+  - type: textarea
+    id: project-context
+    attributes:
+      label: Project context
+      description: Which project surfaced this need, and where will the block be used? Include a Figma link if available.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!-- See CONTRIBUTING.md for the full guidelines. -->
+
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Affected plugin(s)
+
+<!-- Which top-level plugin directory does this touch? e.g. `counter` -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] Enhancement to an existing block
+- [ ] New block plugin
+- [ ] Tooling / docs / CI
+
+## Checklist
+
+- [ ] This PR covers a **single block plugin** (block-family exception aside).
+- [ ] PHP passes **PHPCS + WPCS**: `vendor/bin/phpcs --standard=.phpcs.xml <dir>`.
+- [ ] JS/CSS is **linted and formatted**: `npm run lint:js`, `npm run lint:css`, `npm run format`.
+- [ ] Tested in the latest **`twenty-*` theme**, including the `trunk` → branch upgrade path.
+- [ ] Static-block `edit`/`save` changes include a **block deprecation**.
+- [ ] Plugin header **`Version:` bumped** and `CHANGELOG.md` / `readme.txt` changelog updated (for releasable changes).
+- [ ] No project-specific styling or data added to the block.
+
+## Screenshots / screencast
+
+<!-- Editor and front-end, where relevant. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,173 @@
+# Contributing
+
+Thanks for contributing to the WordPress.com Special Projects Blocks Monorepo. This
+guide is the canonical, repo-level reference. Longer-form background lives in the
+[project wiki](https://github.com/a8cteam51/special-projects-blocks-monorepo/wiki).
+
+- [Before you start: do you actually need a new block?](#before-you-start-do-you-actually-need-a-new-block)
+- [How the monorepo works](#how-the-monorepo-works)
+- [Local setup](#local-setup)
+- [Creating a new block](#creating-a-new-block)
+- [Updating an existing block](#updating-an-existing-block)
+- [Coding standards](#coding-standards)
+- [Submitting a pull request](#submitting-a-pull-request)
+- [Releases and auto-updates](#releases-and-auto-updates)
+
+## Before you start: do you actually need a new block?
+
+The gold standard for block development is **not creating a new block**. Every block
+we add is maintenance we carry forever. Before proposing one, confirm the need can't
+be met with tools that already exist:
+
+- **Patterns** — for reusable layouts of existing blocks.
+- **The Block Bindings API** — for binding block attributes to dynamic data.
+- **The Interactivity API** — for front-end interactivity on existing blocks.
+- **Block styles / variations / filters** — for restyling or extending core blocks.
+
+See [How to extend a WordPress block](https://developer.wordpress.org/news/2024/08/15/how-to-extend-a-wordpress-block/).
+If a new block is genuinely required, open a **New block proposal** issue first so an
+engineering lead can sign off before development starts.
+
+## How the monorepo works
+
+- Each top-level directory is an **independent, separately-releasable plugin**. There
+  are no npm workspaces — you work inside one plugin directory at a time.
+- The root `special-projects-blocks-monorepo.php` is an optional autoloader. On
+  `plugins_loaded` it includes `<dir>/<dir>.php` **only for directories that contain a
+  `build/` directory**. Running `npm run build` in a plugin is what makes it load.
+- `.github/workflows/make-plugin-release.yml` cuts a GitHub release for each changed
+  top-level directory on pushes to `trunk`. The release tag is
+  `<dir>@<plugin-header-version>` and the release body is that plugin's `readme.txt`.
+- `.utilities/class-wpcomsp-blocks-self-update.php` is the shared self-update class
+  copied into each plugin.
+
+See the [README](./README.md) for the full plugin inventory.
+
+## Local setup
+
+The monorepo is designed to be cloned into the `wp-content/plugins/` directory of a
+local WordPress install:
+
+1. Clone this repository into `wp-content/plugins/`.
+2. In wp-admin, activate **WordPress.com Special Projects Blocks Monorepo Autoloader**.
+3. For each plugin you want to work on:
+   ```sh
+   cd <plugin-directory>
+   npm ci
+   npm run build   # creates build/ — the autoloader now loads this plugin
+   npm run start   # development build with file watching
+   ```
+
+For PHP coding standards, install the root Composer dependencies once:
+
+```sh
+composer run-script packages-install
+```
+
+## Creating a new block
+
+Scaffold from the **monorepo root** with `@wordpress/create-block`, using the `a8csp`
+namespace:
+
+```sh
+npx @wordpress/create-block@latest <plugin-slug> --namespace a8csp
+```
+
+Then follow these rules:
+
+- **Namespace everything `a8csp`.** Keep blocks project-agnostic — no project names,
+  data, or project-specific styling in the block.
+- **One block plugin per directory.** The only exception is tightly-coupled block
+  families (e.g. a `tabs` container with its child `tab` block).
+- **Match the entry filename to the directory:** `<plugin-slug>/<plugin-slug>.php`.
+- **Add a `CHANGELOG.md`** at the plugin root and keep it current.
+- **Keep styling minimal and structural.** Blocks should read like wireframes and
+  render un-broken in the latest `twenty-*` theme. Ship structural CSS only; project
+  styling belongs in the project via
+  [block stylesheets](https://developer.wordpress.org/themes/features/block-stylesheets/).
+  Block-level style *controls* (e.g. colour controls) are fine.
+- **Add PHP filters generously** for dynamically-rendered output — think about the next
+  developer reusing this block in their project.
+- **Write verbose plugin and `block.json` descriptions.** These are reused in automated
+  tooling, so be clear and specific.
+- **Add a `screenshot.png`** (1200×800) at the plugin root showing the block's purpose.
+  This is used in automated tooling.
+- **Use `counter` and `table-plus` as reference plugins** for structure and `readme.txt`.
+
+## Updating an existing block
+
+Blocks here can be installed on many sites, so changes must benefit all users — not
+just your current project. Project-specific styles and data go in the project, not the
+block.
+
+- **Static blocks:** if you change `edit`/`save` output, add a
+  [block deprecation](https://developer.wordpress.org/news/2023/03/10/block-deprecation-a-tutorial/)
+  so existing content doesn't break.
+- **Dynamic blocks:** no deprecation needed, but reason carefully about how the change
+  affects sites already using the block.
+- **Test an upgrade path:** verify on `trunk` first, then switch to your branch to
+  simulate a plugin update, in the latest `twenty-*` theme.
+
+If you need a list of Special Projects sites using a block to test against, ask an
+engineering lead.
+
+## Coding standards
+
+- **PHP:** PHPCS with WordPress-Extra plus our extras, via the root `.phpcs.xml`:
+  ```sh
+  vendor/bin/phpcs --standard=.phpcs.xml <plugin-directory>
+  ```
+- **JS/CSS:** the tools provided by
+  [`@wordpress/scripts`](https://www.npmjs.com/package/@wordpress/scripts). Each plugin
+  exposes:
+  ```sh
+  npm run lint:js
+  npm run lint:css
+  npm run format
+  ```
+  Do **not** add per-plugin `.eslintrc`/`.prettierrc`/`.stylelintrc` files — `wp-scripts`
+  ships the shared config we rely on.
+
+## Submitting a pull request
+
+`trunk` is protected; every PR is reviewed. Before opening one:
+
+1. Your PR represents a **single block plugin** (block-family exception aside).
+2. PHP passes **PHPCS + WPCS** against `.phpcs.xml`.
+3. JS/CSS is **linted and formatted** with `@wordpress/scripts`.
+4. You've **tested in the latest `twenty-*` theme**, and added deprecations for any
+   static-block `edit`/`save` changes.
+5. Bump the plugin header `Version:` and add a `CHANGELOG.md`/`readme.txt` changelog
+   entry when releasing changes — the release workflow reads the **PHP header version**.
+
+## Releases and auto-updates
+
+Releases are automatic on merge to `trunk` (see [How the monorepo works](#how-the-monorepo-works)).
+To make a plugin self-update on installed sites:
+
+1. Add the update URI to the plugin header so its hostname matches the update filter:
+   ```
+   Update URI: https://opsoasis.wpspecialprojects.com/<plugin-slug>/
+   ```
+2. Copy `.utilities/class-wpcomsp-blocks-self-update.php` into the plugin's `classes/`
+   directory and wire it up in the entry PHP file:
+   ```php
+   // If no other WPCOMSP block plugin already loaded the self-update class, load it.
+   if ( ! class_exists( 'WPCOMSP_Blocks_Self_Update' ) ) {
+       require __DIR__ . '/classes/class-wpcomsp-blocks-self-update.php';
+
+       $wpcomsp_blocks_self_update = WPCOMSP_Blocks_Self_Update::get_instance();
+       $wpcomsp_blocks_self_update->hooks();
+   }
+
+   add_filter(
+       'wpcomsp_installed_blocks',
+       function ( $blocks ) {
+           $blocks[] = '<plugin-slug>'; // enables auto-updates for this plugin.
+           return $blocks;
+       }
+   );
+   ```
+
+Registering the slug on the `wpcomsp_installed_blocks` filter keeps auto-updates working
+even when a site has several monorepo plugins installed.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ contains a root autoloader plus independently releasable plugin folders.
 Additional project documentation may live in the
 [repository wiki](https://github.com/a8cteam51/special-projects-blocks-monorepo/wiki).
 
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to set up, build, and submit changes,
+and the [wiki](https://github.com/a8cteam51/special-projects-blocks-monorepo/wiki) for
+longer-form process docs.
+
 ## What is here
 
 - `special-projects-blocks-monorepo.php` is an optional root plugin autoloader.
@@ -133,6 +137,13 @@ through the `update_plugins_opsoasis.wpspecialprojects.com` update filter.
 - When adding a new plugin directory, use a matching `<directory>.php` entry
   point and ensure the build produces the `build/` directory expected by the root
   autoloader.
+
+## Contributing
+
+Read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pull request. It covers the
+"do you actually need a new block?" gate, local setup, scaffolding new blocks with the
+`a8csp` namespace, coding standards, and the PR checklist. Use the issue templates to
+file bug reports, enhancements, or new-block proposals.
 
 ## License
 


### PR DESCRIPTION
## Summary

Adds the GitHub contribution scaffolding the repo was missing. Contributors currently have to pattern-match existing PRs; this gives them an authoritative front door.

- **`CONTRIBUTING.md`** — consolidates the wiki (the "do you actually need a new block?" gate, local setup, scaffolding with the `a8csp` namespace, coding standards, PR checklist, and the self-update drop-in) into one repo-level doc.
- **`.github/ISSUE_TEMPLATE/`** — `bug_report`, `feature_request`, and `new_block_proposal` forms (the proposal form encodes the new-block gate), plus a `config.yml` linking the wiki and contributing guide. Forms auto-apply existing labels and offer a dropdown of all plugin directories.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — single-block-plugin rule + PHPCS / `wp-scripts` lint / theme-testing checklist.
- **`.github/CODEOWNERS`** — `@a8cteam51/team51-internal-devs` as global owner.
- **`README.md`** — links to `CONTRIBUTING.md`.

Independent of the other hygiene PRs; merges cleanly in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided issue forms for bug reports, feature requests, and new block proposals.
  * Added a structured pull request template to standardize submissions.
  * Added contributor documentation and updated the README to point to the new guidance.

* **Chores**
  * Enabled blank issues and added helpful contact links for support and process questions.
  * Set a default review path for repository changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->