### PR TITLE
Normalize author identity and resolve the license mismatch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,338 @@
-MIT License
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
-Copyright (c) 2023 WordPress.com Special Projects
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,6 @@ through the `update_plugins_opsoasis.wpspecialprojects.com` update filter.
 
 ## License
 
-The tracked root `LICENSE` file is MIT. Root package metadata, Composer
-metadata, and plugin headers declare `GPL-2.0-or-later`; resolve that mismatch
-before relying on a single repository-wide license declaration.
+This project is licensed under `GPL-2.0-or-later`. The root `LICENSE` file,
+package metadata, Composer metadata, and plugin headers all declare
+`GPL-2.0-or-later`.

--- a/bp-breadcrumbs/breadcrumbs.php
+++ b/bp-breadcrumbs/breadcrumbs.php
@@ -5,7 +5,8 @@
  * Version:           0.1.0
  * Requires at least: 6.8
  * Requires PHP:      7.4
- * Author:            The WordPress Contributors
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       a8csp-breadcrumbs-block

--- a/bp-breadcrumbs/package.json
+++ b/bp-breadcrumbs/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "breadcrumbs",
 	"version": "0.1.0",
-	"description": "Example block scaffolded with Create Block tool.",
-	"author": "The WordPress Contributors",
+	"description": "Breadcrumb navigation blocks for BuddyPress and bbPress.",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/bp-breadcrumbs/readme.txt
+++ b/bp-breadcrumbs/readme.txt
@@ -1,5 +1,5 @@
 === Breadcrumbs ===
-Contributors:      The WordPress Contributors
+Contributors:      wpspecialprojects
 Tags:              block
 Tested up to:      6.8
 Stable tag:        0.1.0

--- a/bp-groups/bp-groups.php
+++ b/bp-groups/bp-groups.php
@@ -5,7 +5,8 @@
  * Version:           0.1.0
  * Requires at least: 6.8
  * Requires PHP:      7.4
- * Author:            The WordPress Contributors
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       bp-groups-blocks

--- a/bp-groups/package.json
+++ b/bp-groups/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "bp-groups",
 	"version": "0.1.0",
-	"description": "Example block scaffolded with Create Block tool.",
-	"author": "The WordPress Contributors",
+	"description": "BuddyPress-gated blocks for group lists, contributors, progress bars, and group variations.",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/bp-groups/readme.txt
+++ b/bp-groups/readme.txt
@@ -1,5 +1,5 @@
 === Bp Groups Gutenberg ===
-Contributors:      The WordPress Contributors
+Contributors:      wpspecialprojects
 Tags:              block BuddyPress
 Tested up to:      6.8
 Stable tag:        0.1.0

--- a/bp-groups/src/bp-groups-list/block.json
+++ b/bp-groups/src/bp-groups-list/block.json
@@ -6,10 +6,13 @@
 	"title": "BP Groups List",
 	"category": "widgets",
 	"icon": "buddicons-groups",
-	"description": "Example block scaffolded with Create Block tool.",
+	"description": "Display a list of BuddyPress groups.",
 	"example": {},
 	"supports": {
-		"align": [ "wide", "full" ],
+		"align": [
+			"wide",
+			"full"
+		],
 		"allowedBlocks": true,
 		"color": {
 			"text": true,
@@ -20,7 +23,10 @@
 		"layout": true,
 		"reusable": false,
 		"spacing": {
-			"blockGap": [ "horizontal", "vertical" ],
+			"blockGap": [
+				"horizontal",
+				"vertical"
+			],
 			"margin": true,
 			"padding": true
 		}

--- a/bp-members/bp-members.php
+++ b/bp-members/bp-members.php
@@ -5,7 +5,8 @@
  * Version:           0.1.0
  * Requires at least: 6.8
  * Requires PHP:      7.4
- * Author:            The WordPress Contributors
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       bp-members-blocks

--- a/bp-members/package.json
+++ b/bp-members/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "bp-members",
 	"version": "0.1.0",
-	"description": "Example block scaffolded with Create Block tool.",
-	"author": "The WordPress Contributors",
+	"description": "BuddyPress-gated member list and member variation blocks.",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/bp-members/readme.txt
+++ b/bp-members/readme.txt
@@ -1,5 +1,5 @@
 === Bp Members ===
-Contributors:      The WordPress Contributors
+Contributors:      wpspecialprojects
 Tags:              block
 Tested up to:      6.8
 Stable tag:        0.1.0

--- a/counter/counter.php
+++ b/counter/counter.php
@@ -5,8 +5,8 @@
  * Version:           0.1.1
  * Requires at least: 6.7
  * Requires PHP:      7.4
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/counter/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/counter/package.json
+++ b/counter/package.json
@@ -2,7 +2,7 @@
 	"name": "counter",
 	"version": "0.1.1",
 	"description": "Allows adding an animated counter to your content. Just pick a start and end",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/counter/readme.txt
+++ b/counter/readme.txt
@@ -1,5 +1,5 @@
 === Counter Block ===
-Contributors:      The WordPress Contributors
+Contributors:      wpspecialprojects
 Tags:              block, counter, animation, numbers
 Tested up to:      6.7
 Stable tag:        1.0.0

--- a/cover-bg-crossfade/cover-bg-crossfade.php
+++ b/cover-bg-crossfade/cover-bg-crossfade.php
@@ -3,8 +3,8 @@
  * Plugin Name:       Cover Background Crossfade
  * Description:       Adds Crossfading background images or videos of multiple cover blocks on a single page based on their scroll position.
  * Version:           0.1.0
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/cover-bg-crossfade/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/cover-bg-crossfade/package.json
+++ b/cover-bg-crossfade/package.json
@@ -2,7 +2,7 @@
 	"name": "cover-bg-crossfade",
 	"version": "0.1.0",
 	"description": "Adds ability to crossfade between fixed cover backgrounds of multiple cover blocks on a single page based on their scroll position.",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"scripts": {
 		"build": "wp-scripts build src/view --output-path=build/view",

--- a/dynamic-table-of-contents/dynamic-table-of-contents.php
+++ b/dynamic-table-of-contents/dynamic-table-of-contents.php
@@ -5,8 +5,8 @@
  * Requires at least: 6.1
  * Requires PHP:      8.0
  * Version:           0.2.0
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/dynamic-table-of-contents/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/dynamic-table-of-contents/package.json
+++ b/dynamic-table-of-contents/package.json
@@ -2,7 +2,7 @@
     "name": "dynamic-table-of-contents",
     "version": "0.2.0",
     "description": "Creates a table of contents that's dynamically (PHP) rendered.",
-    "author": "The WordPress Contributors",
+    "author": "Automattic Special Projects Team",
     "license": "GPL-2.0-or-later",
     "main": "build/index.js",
     "scripts": {

--- a/exclude-duplicates-from-query-loops/exclude-duplicates-from-query-loops.php
+++ b/exclude-duplicates-from-query-loops/exclude-duplicates-from-query-loops.php
@@ -3,8 +3,8 @@
  * Plugin Name:       Exclude Duplicate Posts from Query Loops
  * Description:       Exclude posts from query loops that have already been displayed on the current page.
  * Version:           0.1.0
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/exclude-duplicates-from-query-loops/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/exclude-duplicates-from-query-loops/package.json
+++ b/exclude-duplicates-from-query-loops/package.json
@@ -2,7 +2,7 @@
 	"name": "exclude-duplicates-from-query-loops",
 	"version": "0.1.0",
 	"description": "Exclude posts from query loops that have already been displayed on the current page.",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"scripts": {
 		"build": "wp-scripts build src/editor --output-path=build/editor",

--- a/featured-image-captions/featured-image-captions.php
+++ b/featured-image-captions/featured-image-captions.php
@@ -6,7 +6,7 @@
  * Requires PHP:      8.0
  * Version:           1.0.0
  * Author:            Automattic Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/featured-image-captions/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/featured-image-captions/readme.txt
+++ b/featured-image-captions/readme.txt
@@ -1,5 +1,5 @@
 === Featured Image Captions ===
-Contributors:      The WordPress Contributors
+Contributors:      wpspecialprojects
 Tags:              block, featured-image, caption, image
 Requires at least: 6.1
 Tested up to:      6.7

--- a/featured-video/featured-video.php
+++ b/featured-video/featured-video.php
@@ -3,8 +3,8 @@
  * Plugin Name: Featured Video
  * Description: Add the ability to use Featured Video inplace of Featured Image. <strong>Supported Block:</strong> core/post-featured-image
  * Version: 0.3.0
- * Author: WordPress Special Projects Team
- * Author URI: https://wpspecialprojects.wordpress.com/
+ * Author: Automattic Special Projects Team
+ * Author URI: https://specialprojects.automattic.com/
  * Update URI: https://opsoasis.wpspecialprojects.com/featured-video/
  * License: GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/featured-video/package.json
+++ b/featured-video/package.json
@@ -2,7 +2,7 @@
 	"name": "featured-video",
 	"version": "0.3.0",
 	"description": "Add the ability to use Featured Video inplace of Featured Image.",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"scripts": {
 		"build": "wp-scripts build src/editor --output-path=build/editor && wp-scripts build src/view --output-path=build/view",

--- a/flowing-column/flowing-column.php
+++ b/flowing-column/flowing-column.php
@@ -5,7 +5,8 @@
  * Version:           0.1.0
  * Requires at least: 6.7
  * Requires PHP:      7.4
- * Author:            Automattic Special Projects (Tom Rhodes)
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       flowing-column

--- a/flowing-column/package.json
+++ b/flowing-column/package.json
@@ -2,7 +2,7 @@
 	"name": "flowing-column",
 	"version": "0.1.0",
 	"description": "A block that allows you to create a flowing column layout, like a newspaper.",
-	"author": "Automattic Special Projects",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/flowing-column/readme.txt
+++ b/flowing-column/readme.txt
@@ -1,5 +1,5 @@
 === Flowing Column ===
-Contributors:      tommusrhodus
+Contributors:      wpspecialprojects
 Tags:              block, columns, layout, responsive
 Tested up to:      6.7
 Stable tag:        0.1.0

--- a/jp-related-posts-query-loop/jp-related-posts-query-loop.php
+++ b/jp-related-posts-query-loop/jp-related-posts-query-loop.php
@@ -3,8 +3,8 @@
  * Plugin Name:       Jetpack Related Posts Query Loop
  * Description:       Adds a query loop variation to display related posts from Jetpack.
  * Version:           0.2.0
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/jp-related-posts-query-loop/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/jp-related-posts-query-loop/package.json
+++ b/jp-related-posts-query-loop/package.json
@@ -2,7 +2,7 @@
 	"name": "jp-related-posts-query-loop",
 	"version": "0.2.0",
 	"description": "Adds a query loop variation to display related posts from Jetpack.",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"scripts": {
 		"build": "echo 'No js build step necessary.'",

--- a/light-dark-toggle/light-dark-toggle.php
+++ b/light-dark-toggle/light-dark-toggle.php
@@ -5,8 +5,8 @@
  * Version:           0.2.1
  * Requires at least: 6.7
  * Requires PHP:      7.4
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/light-dark-toggle/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/light-dark-toggle/package.json
+++ b/light-dark-toggle/package.json
@@ -2,7 +2,7 @@
 	"name": "light-dark-toggle",
 	"version": "0.2.1",
 	"description": "Allows a site to have a light and dark mode toggle.",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/light-dark-toggle/readme.txt
+++ b/light-dark-toggle/readme.txt
@@ -1,5 +1,5 @@
 === Light Dark Toggle ===
-Contributors:      The WordPress Contributors
+Contributors:      wpspecialprojects
 Tags:              block
 Tested up to:      6.7
 Stable tag:        1.0.0

--- a/mega-menu/mega-menu.php
+++ b/mega-menu/mega-menu.php
@@ -5,8 +5,8 @@
  * Version:           0.2.2
  * Requires at least: 6.6
  * Requires PHP:      7.2
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/mega-menu/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/mega-menu/package.json
+++ b/mega-menu/package.json
@@ -2,7 +2,7 @@
 	"name": "mega-menu",
 	"version": "0.2.2",
 	"description": "An interactive block with the Interactivity API.",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/modal/modal.php
+++ b/modal/modal.php
@@ -5,8 +5,8 @@
  * Version:           0.1.2
  * Requires at least: 6.6
  * Requires PHP:      7.2
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/modal/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/modal/package.json
+++ b/modal/package.json
@@ -2,7 +2,7 @@
 	"name": "modal",
 	"version": "0.1.2",
 	"description": "An interactive block with the Interactivity API.",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/override-post-links/override-post-links.php
+++ b/override-post-links/override-post-links.php
@@ -5,8 +5,8 @@
  * Version:           0.1.1
  * Requires at least: 6.7
  * Requires PHP:      7.4
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/override-post-links/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/override-post-links/package.json
+++ b/override-post-links/package.json
@@ -2,7 +2,7 @@
 	"name": "override-post-links",
 	"version": "0.1.1",
 	"description": "Add a panel in the WP Admin allowing the user to enter a link which overrides the post links to the new link.",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/override-post-links/readme.txt
+++ b/override-post-links/readme.txt
@@ -1,5 +1,5 @@
 === Override Post Links ===
-Contributors:      The WordPress Contributors
+Contributors:      wpspecialprojects
 Tags:              block
 Tested up to:      6.7
 Stable tag:        0.1.0

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "build": "node .scripts/build-all.js && rm -rf node_modules"
   },
   "devDependencies": {
-	"glob": "^11.0.0"
+    "glob": "^11.0.0"
   },
   "engines": {
     "node": ">=18.0.0",
     "npm": ">=8.0.0"
   },
-  "author": "WordPress Special Projects Team",
+  "author": "Automattic Special Projects Team",
   "license": "GPL-2.0-or-later"
 }

--- a/reactions/package.json
+++ b/reactions/package.json
@@ -2,7 +2,7 @@
 	"name": "reactions",
 	"version": "0.1.1",
 	"description": "A plugin to add reactions to your posts.",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"scripts": {
 		"build": "wp-scripts build --webpack-copy-php --experimental-modules",

--- a/reactions/reactions.php
+++ b/reactions/reactions.php
@@ -5,8 +5,8 @@
  * Requires at least: 6.6
  * Requires PHP:      8.0
  * Version:           0.1.1
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/reactions/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/scroll-progress-bar/package.json
+++ b/scroll-progress-bar/package.json
@@ -2,7 +2,7 @@
 	"name": "scroll-progress-bar",
 	"version": "0.1.1",
 	"description": "Progress bar that updates as you scroll down the page.",
-	"author": "Automattic Special Projects",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/scroll-progress-bar/readme.txt
+++ b/scroll-progress-bar/readme.txt
@@ -1,5 +1,5 @@
 === Scroll Progress Bar ===
-Contributors:      The WordPress Contributors
+Contributors:      wpspecialprojects
 Tags:              block
 Tested up to:      6.7
 Stable tag:        0.1.0

--- a/scroll-progress-bar/scroll-progress-bar.php
+++ b/scroll-progress-bar/scroll-progress-bar.php
@@ -5,7 +5,8 @@
  * Version:           0.1.1
  * Requires at least: 6.7
  * Requires PHP:      7.4
- * Author:            Automattic Special Projects
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       scroll-progress-bar

--- a/scroll-to-top/package.json
+++ b/scroll-to-top/package.json
@@ -2,7 +2,7 @@
 	"name": "scroll-to-top",
 	"version": "0.1.1",
 	"description": "A block to add a scroll to top button to the page.",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {
@@ -17,8 +17,7 @@
 	"files": [
 		"[^.]*"
 	],
-	"dependencies": {
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"@wordpress/scripts": "^30.1.0"
 	}

--- a/scroll-to-top/readme.txt
+++ b/scroll-to-top/readme.txt
@@ -1,5 +1,5 @@
 === Scroll to Top ===
-Contributors:      WordPress.com Special Projects Team
+Contributors:      wpspecialprojects
 Tags:              block, scroll, button
 Tested up to:      6.1
 Stable tag:        0.1.1

--- a/scroll-to-top/scroll-to-top.php
+++ b/scroll-to-top/scroll-to-top.php
@@ -5,8 +5,8 @@
  * Requires at least: 6.1
  * Requires PHP:      7.0
  * Version:           0.1.1
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/scroll-to-top/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/sibling-pages-list/package.json
+++ b/sibling-pages-list/package.json
@@ -2,7 +2,7 @@
 	"name": "sibling-pages-list",
 	"version": "0.1.1",
 	"description": "Displays a list of the current page's sibling pages",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/sibling-pages-list/sibling-pages-list.php
+++ b/sibling-pages-list/sibling-pages-list.php
@@ -5,8 +5,8 @@
  * Requires at least: 6.1
  * Requires PHP:      7.0
  * Version:           0.1.1
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/sibling-pages-list/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/special-projects-blocks-monorepo.php
+++ b/special-projects-blocks-monorepo.php
@@ -5,8 +5,8 @@
  * Requires at least: 6.1
  * Requires PHP:      8.0
  * Version:           1.1.0
- * Author:            WordPress.com Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://github.com/a8cteam51/special-projects-blocks-monorepo/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/stretchy-type/package.json
+++ b/stretchy-type/package.json
@@ -2,7 +2,7 @@
 	"name": "stretchy-type",
 	"version": "0.1.3",
 	"description": "A block that expands to fill the width of its container.",
-	"author": "Automattic Special Projects",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/stretchy-type/stretchy-type.php
+++ b/stretchy-type/stretchy-type.php
@@ -5,8 +5,8 @@
  * Requires at least: 6.1
  * Requires PHP:      7.0
  * Version:           0.1.3
- * Author:            Automattic Special Projects
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       stretchy-type

--- a/table-plus/package.json
+++ b/table-plus/package.json
@@ -2,7 +2,7 @@
 	"name": "table-plus",
 	"version": "0.1.0",
 	"description": "A structured, flexible table block with per-cell editing, header/footer rows, and customisable borders.",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/table-plus/readme.txt
+++ b/table-plus/readme.txt
@@ -1,5 +1,5 @@
 === Table Plus ===
-Contributors:      The WordPress Contributors
+Contributors:      wpspecialprojects
 Tags:              block, table, gutenberg
 Requires at least: 6.8
 Tested up to:      6.8

--- a/table-plus/table-plus.php
+++ b/table-plus/table-plus.php
@@ -5,8 +5,8 @@
  * Requires at least: 6.8
  * Requires PHP:      7.4
  * Version:           0.1.0
- * Author:            WordPress Special Projects Team
- * Author URI:        https://wpspecialprojects.wordpress.com/
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/table-plus/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/tabs/package.json
+++ b/tabs/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"version": "0.1.2",
 	"description": "A block that allows users to organize content into tabs.",
-	"author": "WordPress Special Projects Team",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"homepage": "https://wpspecialprojects.wordpress.com/",
 	"scripts": {

--- a/tabs/tabs.php
+++ b/tabs/tabs.php
@@ -5,8 +5,9 @@
  * Description:       A block that allows users to organize content into tabs.
  * Requires at least: 6.5
  * Requires PHP:      8.0
- * Version:           0.1.1
- * Author:            WordPress Special Projects Team
+ * Version:           0.1.2
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       tabs

--- a/videopress-download/package.json
+++ b/videopress-download/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "videopress-download",
 	"version": "0.1.0",
-	"description": "Example block scaffolded with Create Block tool.",
-	"author": "The WordPress Contributors",
+	"description": "Adds a download button to VideoPress videos in a post.",
+	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {

--- a/videopress-download/readme.txt
+++ b/videopress-download/readme.txt
@@ -1,5 +1,5 @@
 === Videopress Download ===
-Contributors:      The WordPress Contributors
+Contributors:      wpspecialprojects
 Tags:              block
 Tested up to:      6.7
 Stable tag:        0.1.0

--- a/videopress-download/videopress-download.php
+++ b/videopress-download/videopress-download.php
@@ -5,7 +5,8 @@
  * Version:           0.1.0
  * Requires at least: 6.7
  * Requires PHP:      7.4
- * Author:            The WordPress Contributors
+ * Author:            Automattic Special Projects Team
+ * Author URI:        https://specialprojects.automattic.com/
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       videopress-download


### PR DESCRIPTION
## Summary

Collapses the 6+ author variants that were spread across three surfaces (PHP headers, `package.json`, `readme.txt` Contributors) to a single canonical identity, and resolves the repository license mismatch.

- **Author** (all plugin PHP headers + every `package.json`, incl. the root autoloader and root `package.json`) → `Automattic Special Projects Team`.
- **Author URI** → `https://specialprojects.automattic.com/` (added where missing, with aligned header formatting).
- **`readme.txt` Contributors** → `wpspecialprojects` (the valid wp.org username). The 7 plugins whose `readme.txt` is rewritten in #166 are intentionally left out here to avoid churn — together the two PRs cover all 23 and merge cleanly.
- Replaces the create-block scaffold descriptions in `bp-breadcrumbs`, `bp-groups`, `bp-members`, `videopress-download`, and the `bp-groups-list` block.
- Aligns the `tabs` PHP header version (0.1.1) with `package.json`/`block.json` (0.1.2).
- **License:** replaces the root `LICENSE` (was MIT) with the GPL-2.0 text so it matches the `GPL-2.0-or-later` declared in every manifest and plugin header; updates the README license section.

> Note: the release workflow fires on any change to a plugin dir, so merging this re-publishes releases at existing versions. No version bumps were made (per maintainer choice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
