### PR TITLE
Dynamic TOC: add toggle to include headings from wrapper blocks (accordions, etc.)

### DIFF
--- a/dynamic-table-of-contents/CHANGELOG.md
+++ b/dynamic-table-of-contents/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.3.0 - 2026-06-26
+
+### Added
+
+- New **Include headings nested in other blocks** toggle (off by default). When enabled, the table of contents also lists headings rendered by wrapper blocks such as accordions, which split their title across child elements and never receive a server-side anchor. The view script generates an anchor for each such heading from its text and links to it.
+
+### Fixed
+
+- Heading labels no longer include decorative, `aria-hidden` icons (for example an accordion toggle's `+`/`-` marker), so entries read as the heading text alone.
+- The scroll-spy `IntersectionObserver` no longer throws when a heading has no matching table-of-contents link.
+
 ## 0.2.0 - 2026-04-27
 
 ### Added

--- a/dynamic-table-of-contents/dynamic-table-of-contents.php
+++ b/dynamic-table-of-contents/dynamic-table-of-contents.php
@@ -4,7 +4,7 @@
  * Description:       Creates a table of contents that's dynamically (PHP) rendered.
  * Requires at least: 6.1
  * Requires PHP:      8.0
- * Version:           0.2.0
+ * Version:           0.3.0
  * Author:            Automattic Special Projects Team
  * Author URI:        https://specialprojects.automattic.com/
  * Update URI:        https://opsoasis.wpspecialprojects.com/dynamic-table-of-contents/

--- a/dynamic-table-of-contents/package-lock.json
+++ b/dynamic-table-of-contents/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dynamic-table-of-contents",
-    "version": "0.1.9",
+    "version": "0.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "dynamic-table-of-contents",
-            "version": "0.1.9",
+            "version": "0.3.0",
             "license": "GPL-2.0-or-later",
             "devDependencies": {
                 "@wordpress/scripts": "^26.18.0"

--- a/dynamic-table-of-contents/package.json
+++ b/dynamic-table-of-contents/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dynamic-table-of-contents",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Creates a table of contents that's dynamically (PHP) rendered.",
     "author": "Automattic Special Projects Team",
     "license": "GPL-2.0-or-later",

--- a/dynamic-table-of-contents/readme.txt
+++ b/dynamic-table-of-contents/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      wpspecialprojects
 Tags:              block, table of contents, navigation, headings, accessibility
 Tested up to:      6.8
-Stable tag:        0.2.0
+Stable tag:        0.3.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,6 +18,7 @@ The list is assembled in the browser at render time from the post's live heading
 
 * **Self-building list** — the table of contents is generated on the frontend from the post's headings; there is no manual list to maintain.
 * **Automatic heading anchors** — a `render_block` filter adds an `id` (slugified from the heading text) to every `core/heading` that lacks one, so each table entry links to its section. Headings that already have an `id` are left untouched.
+* **Headings from wrapper blocks** — an optional **Include headings nested in other blocks** toggle lists headings rendered by blocks such as accordions (which wrap their title in extra elements and so never get a server-side anchor). When enabled, the view script generates an anchor for each such heading and ignores decorative, `aria-hidden` icons when building the label.
 * **Scroll-spy highlighting** — an `IntersectionObserver` watches the headings and adds an `active` class to the matching link as each section scrolls into view, so the table tracks the reader's position. The active entry is shown in bold.
 * **Editable title** — the block title is editable inline via RichText and defaults to "Table of Contents". An empty title is omitted from the output.
 * **Heading selection filter** — by default the table collects all `h1`–`h6` headings inside `.wp-block-post-content`. The `a8csp_dynamic_table_of_contents_heading_selectors` filter lets you change which headings are listed (for example, H2 only).
@@ -64,6 +65,10 @@ add_filter(
 );
 `
 
+= Why are accordion (or other wrapper-block) headings missing from the list? =
+
+The automatic anchor only runs on `core/heading` blocks. Headings rendered by other blocks — such as accordions, which wrap their title in a button and extra `span` elements — never receive a server-side `id`, so by default they are skipped. Enable the **Include headings nested in other blocks** toggle in the block's settings to list them; the view script then generates an anchor for each from its text and links the entry to it. Decorative, `aria-hidden` icons (like an accordion toggle's `+`/`-`) are ignored when building the label.
+
 = Why doesn't the block show up on a page or in other contexts? =
 
 The block renders only when it has a post context (a `postId`). It is designed for the singular post view, where a table of contents for the post's headings makes sense, and is intentionally skipped elsewhere.
@@ -77,6 +82,11 @@ The view script uses an `IntersectionObserver` to track which heading is in view
 Yes. The title is editable inline in the editor and defaults to "Table of Contents". Leaving it empty removes it from the output. You can also adjust the rendered title programmatically with the `wpcomsp_dynamic_table_of_contents_block_title` filter.
 
 == Changelog ==
+
+= 0.3.0 =
+* Added an **Include headings nested in other blocks** toggle (off by default) that lists headings from wrapper blocks such as accordions, generating an anchor for each from its text.
+* Heading labels now ignore decorative, `aria-hidden` icons (for example an accordion toggle's `+`/`-` marker).
+* The scroll-spy `IntersectionObserver` no longer throws when a heading has no matching table-of-contents link.
 
 = 0.2.0 =
 * Server-rendered table of contents block that builds its list on the frontend from the post's headings.

--- a/dynamic-table-of-contents/src/block.json
+++ b/dynamic-table-of-contents/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "wpcomsp/dynamic-table-of-contents",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"title": "Dynamic Table of Contents",
 	"category": "design",
 	"description": "Creates a table of contents that's dynamically (PHP) rendered.",
@@ -34,6 +34,10 @@
 		"title": {
 			"type": "string",
 			"default": "Table of Contents"
+		},
+		"includeNestedHeadings": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"textdomain": "dynamic-table-of-contents",

--- a/dynamic-table-of-contents/src/edit.js
+++ b/dynamic-table-of-contents/src/edit.js
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
-import { useBlockProps, RichText } from '@wordpress/block-editor';
+import { useBlockProps, RichText, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 
 /**
  * The edit function describes the structure of your block in the context of the
@@ -11,25 +12,43 @@ import { useBlockProps, RichText } from '@wordpress/block-editor';
  */
 export default function Edit({ attributes, setAttributes }) {
 	return (
-		<div {...useBlockProps()}>
-			<RichText
-				tagName="h2"
-				placeholder={__('Table of Contents Title', 'dynamic-table-of-contents')}
-				value={attributes.title}
-				onChange={(title) => setAttributes({ title })}
-				className="table-of-contents-title"
-			/>
-			<ul className="table-of-contents-list">
-				<li className="table-of-contents-list-item">
-					<a href="#" className='active'>This is an example.</a>
-				</li>
-				<li className="table-of-contents-list-item">
-					<a href="#">Of the block appearance.</a>
-				</li>
-				<li className="table-of-contents-list-item">
-					<a href="#">When used in your post.</a>
-				</li>
-			</ul>
-		</div>
+		<>
+			<InspectorControls>
+				<PanelBody title={__('Settings', 'dynamic-table-of-contents')}>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={__('Include headings nested in other blocks', 'dynamic-table-of-contents')}
+						help={__(
+							'List headings that come from wrapper blocks such as accordions, which split their title across extra elements. These headings have no anchor of their own, so one is generated from the heading text on the frontend.',
+							'dynamic-table-of-contents'
+						)}
+						checked={!!attributes.includeNestedHeadings}
+						onChange={(includeNestedHeadings) =>
+							setAttributes({ includeNestedHeadings })
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div {...useBlockProps()}>
+				<RichText
+					tagName="h2"
+					placeholder={__('Table of Contents Title', 'dynamic-table-of-contents')}
+					value={attributes.title}
+					onChange={(title) => setAttributes({ title })}
+					className="table-of-contents-title"
+				/>
+				<ul className="table-of-contents-list">
+					<li className="table-of-contents-list-item">
+						<a href="#" className='active'>This is an example.</a>
+					</li>
+					<li className="table-of-contents-list-item">
+						<a href="#">Of the block appearance.</a>
+					</li>
+					<li className="table-of-contents-list-item">
+						<a href="#">When used in your post.</a>
+					</li>
+				</ul>
+			</div>
+		</>
 	);
 }

--- a/dynamic-table-of-contents/src/render.php
+++ b/dynamic-table-of-contents/src/render.php
@@ -46,11 +46,14 @@ $heading_selectors = apply_filters(
 	$block
 );
 
+$include_nested_headings = ! empty( $attributes['includeNestedHeadings'] );
+
 wp_add_inline_script(
 	'wpcomsp-dynamic-table-of-contents-view',
 	sprintf(
-		'window.wpcomspDynamicTOC=window.wpcomspDynamicTOC||{};window.wpcomspDynamicTOC.headingSelectors=%s;',
-		wp_json_encode( implode( ', ', $heading_selectors ) )
+		'window.wpcomspDynamicTOC=window.wpcomspDynamicTOC||{};window.wpcomspDynamicTOC.headingSelectors=%1$s;window.wpcomspDynamicTOC.includeNestedHeadings=%2$s;',
+		wp_json_encode( implode( ', ', $heading_selectors ) ),
+		wp_json_encode( $include_nested_headings )
 	),
 	'before'
 );

--- a/dynamic-table-of-contents/src/view.js
+++ b/dynamic-table-of-contents/src/view.js
@@ -1,7 +1,56 @@
 const $defaultHeadingSelectors = '.wp-block-post-content h1, .wp-block-post-content h2, .wp-block-post-content h3, .wp-block-post-content h4, .wp-block-post-content h5, .wp-block-post-content h6';
-const $headingSelectors = (window.wpcomspDynamicTOC && window.wpcomspDynamicTOC.headingSelectors) || $defaultHeadingSelectors;
+const $config = window.wpcomspDynamicTOC || {};
+const $headingSelectors = $config.headingSelectors || $defaultHeadingSelectors;
+const $includeNestedHeadings = Boolean($config.includeNestedHeadings);
 const $headings = document.querySelectorAll($headingSelectors);
 const $headingList = document.querySelector('.wp-block-wpcomsp-dynamic-table-of-contents ul');
+
+/**
+ * Get a heading's visible text.
+ *
+ * Headings rendered by wrapper blocks (e.g. accordions) split their title
+ * across child elements and add decorative, aria-hidden icons. Cloning the node
+ * and dropping aria-hidden children keeps toggle markers like "+"/"-" out of the
+ * table of contents label.
+ *
+ * @param {Element} heading The heading element.
+ * @return {string} The trimmed, visible heading text.
+ */
+function getHeadingText(heading) {
+	const $clone = heading.cloneNode(true);
+	$clone.querySelectorAll('[aria-hidden="true"]').forEach(($el) => $el.remove());
+	return $clone.textContent.trim();
+}
+
+/**
+ * Turn heading text into an anchor-friendly id that is not already used on the
+ * page. Mirrors the server-side `sanitize_title()` slug closely enough for
+ * headings that core never anchored.
+ *
+ * @param {string} text  The heading text.
+ * @param {number} index The heading's position, used as a fallback slug.
+ * @return {string} A unique id.
+ */
+function toUniqueId(text, index) {
+	let $base = text
+		.toLowerCase()
+		.replace(/[^\p{L}\p{N}]+/gu, '-')
+		.replace(/^-+|-+$/g, '');
+
+	if (!$base) {
+		$base = `toc-heading-${index}`;
+	}
+
+	let $id = $base;
+	let $suffix = 2;
+
+	while (null !== document.getElementById($id)) {
+		$id = `${$base}-${$suffix}`;
+		$suffix += 1;
+	}
+
+	return $id;
+}
 
 // This is the observer that will be used to highlight the current heading.
 const $observer = new IntersectionObserver((entries) => {
@@ -11,7 +60,7 @@ const $observer = new IntersectionObserver((entries) => {
 		const $id = entry.target.id;
 		const $link = document.querySelector(`.wp-block-wpcomsp-dynamic-table-of-contents a[href="#${$id}"]`);
 
-		if (entry.isIntersecting) {
+		if (entry.isIntersecting && $link) {
 			$links.forEach((link) => {
 				link.classList.remove('active');
 			});
@@ -24,29 +73,52 @@ const $observer = new IntersectionObserver((entries) => {
 	rootMargin: '0px 0px -75% 0px',
 });
 
+let $isFirstEntry = true;
+
 $headings.forEach((heading, index) => {
-	const $id = heading.id;
-
-	if ($id.length) {
-		// Create new elements.
-		const $latestListItem = document.createElement('li');
-		const $latestLink = document.createElement('a');
-
-		// Add attributes to new elements.
-		$latestLink.href = `#${$id}`;
-		$latestLink.textContent = heading.textContent;
-
-		// Setup the first element as active.
-		if (0 === index) {
-			$latestLink.classList.add('active');
-		}
-
-		// Add new elements to the markup.
-		$latestListItem.appendChild($latestLink);
-		$headingList.appendChild($latestListItem);
-
-		// Setup on scroll highlighting.
-		$observer.observe(heading);
+	// Never list the table of contents' own title.
+	if (heading.closest('.wp-block-wpcomsp-dynamic-table-of-contents')) {
+		return;
 	}
 
+	let $id = heading.id;
+
+	// Headings rendered by wrapper blocks (accordions, etc.) never receive a
+	// server-side anchor. Without the toggle we keep the original behaviour of
+	// only listing headings that already have an id.
+	if (!$id) {
+		if (!$includeNestedHeadings) {
+			return;
+		}
+
+		const $text = getHeadingText(heading);
+
+		if (!$text) {
+			return;
+		}
+
+		$id = toUniqueId($text, index);
+		heading.id = $id;
+	}
+
+	// Create new elements.
+	const $latestListItem = document.createElement('li');
+	const $latestLink = document.createElement('a');
+
+	// Add attributes to new elements.
+	$latestLink.href = `#${$id}`;
+	$latestLink.textContent = getHeadingText(heading);
+
+	// Setup the first listed element as active.
+	if ($isFirstEntry) {
+		$latestLink.classList.add('active');
+		$isFirstEntry = false;
+	}
+
+	// Add new elements to the markup.
+	$latestListItem.appendChild($latestLink);
+	$headingList.appendChild($latestListItem);
+
+	// Setup on scroll highlighting.
+	$observer.observe(heading);
 });


### PR DESCRIPTION
## Problem

The Dynamic Table of Contents only lists headings that carry an `id`. The `render_block` filter adds an anchor to every `core/heading`, but headings rendered by **wrapper blocks** (e.g. `core/accordion-heading`) are not `core/heading` — they never receive a server-side `id`, so the view script (`if ($id.length)`) silently drops them.

Reported as "doesn't expose headings with sub-elements e.g. `<h2><strong>`". Investigation showed the literal `<strong>` case already works (`wp_strip_all_tags` flattens it); the real failure is wrapper-block headings such as an accordion:

```html
<h2 class="wp-block-accordion-heading"><button …><span class="…__toggle-title">Step 1: Build a team and set up</span><span class="…__toggle-icon" aria-hidden="true">+</span></button></h2>
```

No `id`, and the title is split across child spans with a decorative `+` toggle icon.

## Change

- **New block toggle "Include headings nested in other blocks"** (`includeNestedHeadings`, **default off** — existing behaviour unchanged). When on, `view.js` generates an anchor for any id-less heading from its visible text and lists it.
- **Label cleanup:** heading text is read with `aria-hidden="true"` children removed, so toggle icons (`+`/`-`) don't leak into entries.
- **Self-reference guard:** the TOC's own `<h2>` title is excluded from the list (it renders inside `.wp-block-post-content`, so the toggle would otherwise list the TOC inside itself).
- **Observer null-guard:** `IntersectionObserver` no longer throws when a heading has no matching link.
- Version bump 0.2.0 → 0.3.0; changelog/readme updated.

## Verification

Reproduced through the real `render_block`/`do_blocks` path and unit-tested the view logic with jsdom against the exact accordion markup, then confirmed in a real browser on a local site with **core accordion blocks**:

| Toggle | Frontend TOC |
|---|---|
| **off** | `Introduction · Why a Table of Contents Matters · The Steps · Conclusion` (accordion Steps absent — original behaviour) |
| **on** | …`The Steps · Step 1: Build a team and set up · Step 2: Define the workflow · Step 3: Launch and iterate · Conclusion` (clean labels, generated anchors; TOC's own title excluded) |

## Notes

- `build/` is git-ignored and produced by `npm run build`; only `src/` + docs are committed here.
- Known minor: the client-side slug isn't accent-folded like `sanitize_title` (`Café` → `café`), but the entry links to the same generated id, so anchors resolve. Only affects wrapper-block headings (which core never anchors).
- The per-block toggle is read from a single global (`window.wpcomspDynamicTOC`), consistent with the existing `headingSelectors`; with two TOC blocks on one page the last-rendered setting wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)