### PR TITLE
Fix Tabs keyboard focus

### DIFF
--- a/tabs/CHANGELOG.md
+++ b/tabs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.1.3
+
+### Fixed
+
+- Keep the selected tab control focusable so keyboard users can enter and navigate the tablist.
+
 ## 0.1.2
 
 ### Added

--- a/tabs/package-lock.json
+++ b/tabs/package-lock.json
@@ -1,15 +1,16 @@
 {
 	"name": "tabs",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tabs",
-			"version": "0.1.2",
+			"version": "0.1.3",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/icons": "^10.3.0"
+				"@wordpress/icons": "^10.3.0",
+				"fast-deep-equal": "^3.1.3"
 			},
 			"devDependencies": {
 				"@wordpress/scripts": "^30.21.0"
@@ -10291,7 +10292,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"license": "MIT"
 		},
 		"node_modules/fast-diff": {
 			"version": "1.3.0",

--- a/tabs/package.json
+++ b/tabs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tabs",
 	"private": true,
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "A block that allows users to organize content into tabs.",
 	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",
@@ -16,7 +16,8 @@
 		"start": "wp-scripts start"
 	},
 	"dependencies": {
-		"@wordpress/icons": "^10.3.0"
+		"@wordpress/icons": "^10.3.0",
+		"fast-deep-equal": "^3.1.3"
 	},
 	"devDependencies": {
 		"@wordpress/scripts": "^30.21.0"

--- a/tabs/readme.txt
+++ b/tabs/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      wpspecialprojects
 Tags:              block, tabs, accordion, accessibility, gutenberg
 Tested up to:      6.8
-Stable tag:        0.1.2
+Stable tag:        0.1.3
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -69,6 +69,9 @@ When the tab list overflows its container, left and right scroll arrows appear s
 Yes. Each Tab is an inner-blocks container, so a tab panel can hold any blocks. New tabs start with an empty paragraph that you can replace or build on.
 
 == Changelog ==
+
+= 0.1.3 =
+* Fix frontend keyboard focus for tab controls by keeping the selected tab in the tab order.
 
 = 0.1.2 =
 * Two-block Tabs / Tab architecture with a default two-tab layout.

--- a/tabs/src/tab/block.json
+++ b/tabs/src/tab/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "wpcomsp/tab",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"title": "Tab",
 	"category": "widgets",
 	"description": "Customize content inside a tab.",

--- a/tabs/src/tab/save.js
+++ b/tabs/src/tab/save.js
@@ -3,7 +3,7 @@
  */
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
-export default function save( { attributes: { isActive, tabNumber } } ) {
+export default function save( { attributes: { tabNumber } } ) {
 	const blockProps = useBlockProps.save();
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 

--- a/tabs/src/tabs/block.json
+++ b/tabs/src/tabs/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "wpcomsp/tabs",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"title": "Tabs",
 	"category": "widgets",
 	"description": "Organize content using tabs.",

--- a/tabs/src/tabs/deprecated.js
+++ b/tabs/src/tabs/deprecated.js
@@ -1,0 +1,81 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+function DeprecatedTabButton( { isSelected, tabNumber, title } ) {
+	return (
+		<div
+			id={ `tab-${ tabNumber }` }
+			role="tab"
+			className="tab"
+			aria-selected={ isSelected }
+			aria-controls={ `tabpanel-${ tabNumber }` }
+		>
+			<RichText.Content
+				tagName="span"
+				value={ title }
+				className="tab-button-text"
+			/>
+		</div>
+	);
+}
+
+const v1 = {
+	attributes: {
+		tabs: {
+			type: 'array',
+			default: [],
+		},
+		activeTab: {
+			type: 'number',
+			default: 1,
+		},
+		templateLock: {
+			type: [ 'string', 'boolean' ],
+			enum: [ 'all', 'insert', 'contentOnly', false ],
+		},
+	},
+	save( { attributes: { tabs } } ) {
+		const tabButtons = [];
+		for ( let index = 0; index < tabs?.length; index++ ) {
+			const tabNumber = index + 1;
+			const tabBlock = tabs[ index ];
+			const title = tabBlock?.title || `Tab ${ tabNumber }`;
+			tabButtons.push(
+				<DeprecatedTabButton
+					key={ index }
+					tabNumber={ tabNumber }
+					isSelected={ tabNumber === 1 }
+					title={ title }
+				/>
+			);
+		}
+
+		const blockProps = useBlockProps.save();
+
+		return (
+			<div { ...blockProps }>
+				<div className="tabs-container">
+					<div
+						className="scroll-arrow scroll-arrow-left"
+						role="button"
+						aria-label={ __( 'Scroll tabs left', 'tabs' ) }
+					></div>
+					<div role="tablist" className="tablist-wrapper">
+						{ tabButtons }
+					</div>
+					<div
+						className="scroll-arrow scroll-arrow-right"
+						role="button"
+						aria-label={ __( 'Scroll tabs right', 'tabs' ) }
+					></div>
+				</div>
+				<InnerBlocks.Content />
+			</div>
+		);
+	},
+};
+
+export default [ v1 ];

--- a/tabs/src/tabs/deprecated.js
+++ b/tabs/src/tabs/deprecated.js
@@ -37,6 +37,13 @@ const v1 = {
 			enum: [ 'all', 'insert', 'contentOnly', false ],
 		},
 	},
+	supports: {
+		anchor: true,
+		align: [ 'wide', 'full' ],
+		html: false,
+		interactivity: true,
+		multiple: false,
+	},
 	save( { attributes: { tabs } } ) {
 		const tabButtons = [];
 		for ( let index = 0; index < tabs?.length; index++ ) {

--- a/tabs/src/tabs/edit.js
+++ b/tabs/src/tabs/edit.js
@@ -51,6 +51,11 @@ function TabButton( { clientId, isActiveTab, tabNumber, setActiveTab } ) {
 	};
 
 	const handleKeyDown = ( event ) => {
+		// Ignore keystrokes bubbling up from the RichText title so typing
+		// (e.g. spaces) is not intercepted.
+		if ( event.target !== event.currentTarget ) {
+			return;
+		}
 		if ( event.key === 'Enter' || event.key === ' ' ) {
 			event.preventDefault();
 			setActiveTab();

--- a/tabs/src/tabs/edit.js
+++ b/tabs/src/tabs/edit.js
@@ -50,14 +50,23 @@ function TabButton( { clientId, isActiveTab, tabNumber, setActiveTab } ) {
 		updateBlockAttributes( clientId, { title: newTitle } );
 	};
 
+	const handleKeyDown = ( event ) => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
+			setActiveTab();
+		}
+	};
+
 	return (
 		<div
 			id={ `tab-${ tabNumber }` }
 			role="tab"
-			className='tab'
+			className="tab"
 			aria-selected={ isTabBlockSelected || isActiveTab }
 			aria-controls={ `tabpanel-${ tabNumber }` }
+			tabIndex={ isTabBlockSelected || isActiveTab ? 0 : -1 }
 			onClick={ setActiveTab }
+			onKeyDown={ handleKeyDown }
 		>
 			<RichText
 				tagName="span"
@@ -104,7 +113,9 @@ function TabsEdit( {
 		}
 		if (
 			tabBlocks.length !== tabs.length ||
-			tabBlocks.some( ( block, index ) => ! isEqual( block.attributes, tabs[ index ] ) )
+			tabBlocks.some(
+				( block, index ) => ! isEqual( block.attributes, tabs[ index ] )
+			)
 		) {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
@@ -192,7 +203,8 @@ function TabsEdit( {
 									key={ tabBlock.clientId }
 									clientId={ tabBlock.clientId }
 									isActiveTab={
-										! hasTabSelected && activeTab === tabNumber
+										! hasTabSelected &&
+										activeTab === tabNumber
 									}
 									tabNumber={ tabNumber }
 									setActiveTab={ setAttributes.bind( null, {

--- a/tabs/src/tabs/editor.scss
+++ b/tabs/src/tabs/editor.scss
@@ -4,7 +4,9 @@
 @use "@wordpress/base-styles/breakpoints" as *;
 
 .wp-block-wpcomsp-tabs {
+
 	&.is-selected {
+
 		.block-list-appender {
 			top: -30px;
 			right: 10px;

--- a/tabs/src/tabs/index.js
+++ b/tabs/src/tabs/index.js
@@ -19,6 +19,7 @@ import './style.scss';
 import Edit from './edit';
 import save from './save';
 import metadata from './block.json';
+import deprecated from './deprecated';
 
 const TabsIcon = (
 	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none">
@@ -35,4 +36,5 @@ registerBlockType( metadata.name, {
 	icon: TabsIcon,
 	edit: Edit,
 	save,
+	deprecated,
 } );

--- a/tabs/src/tabs/save.js
+++ b/tabs/src/tabs/save.js
@@ -9,9 +9,10 @@ function TabButton( { isSelected, tabNumber, title } ) {
 		<div
 			id={ `tab-${ tabNumber }` }
 			role="tab"
-			className='tab'
+			className="tab"
 			aria-selected={ isSelected }
 			aria-controls={ `tabpanel-${ tabNumber }` }
+			tabIndex={ isSelected ? 0 : -1 }
 		>
 			<RichText.Content
 				tagName="span"

--- a/tabs/src/tabs/style.scss
+++ b/tabs/src/tabs/style.scss
@@ -5,6 +5,7 @@
 @use "@wordpress/base-styles/mixins" as *;
 
 .wp-block-wpcomsp-tabs {
+
 	.tabs-container {
 		display: flex;
 		align-items: center;
@@ -24,7 +25,7 @@
 		padding: 8px 12px;
 		cursor: pointer;
 		font-size: 16px;
-		font-weight: bold;
+		font-weight: 700;
 		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 		transition: all 0.2s ease;
 
@@ -33,7 +34,7 @@
 		}
 
 		&::before {
-			content: '';
+			content: "";
 			display: inline-block;
 			width: 0;
 			height: 0;
@@ -99,7 +100,7 @@
 		margin: 0 0 -2px;
 		padding: 3px 3px 4px;
 		outline: none;
-		font-weight: bold;
+		font-weight: 700;
 		overflow: hidden;
 		text-align: center;
 		cursor: pointer;
@@ -111,7 +112,7 @@
 		width: 100%;
 
 		&[aria-selected="true"] {
-			border-bottom: 2px solid black;
+			border-bottom: 2px solid #000;
 		}
 
 		.tab-button-text {
@@ -145,6 +146,7 @@
 	}
 
 	@include break-mobile {
+
 		.scroll-arrow {
 			display: block;
 		}

--- a/tabs/src/tabs/view.js
+++ b/tabs/src/tabs/view.js
@@ -18,9 +18,7 @@ class TabsAutomatic {
 		this.firstTab = null;
 		this.lastTab = null;
 
-		this.tabs = Array.from(
-			this.tablistNode.querySelectorAll( '.tab' )
-		);
+		this.tabs = Array.from( this.tablistNode.querySelectorAll( '.tab' ) );
 		this.tabpanels = [];
 
 		for ( let i = 0; i < this.tabs.length; i += 1 ) {
@@ -39,6 +37,14 @@ class TabsAutomatic {
 			}
 			this.lastTab = tab;
 		}
+
+		const selectedTab = this.tabs.find(
+			( tab ) => tab.getAttribute( 'aria-selected' ) === 'true'
+		);
+
+		if ( selectedTab || this.firstTab ) {
+			this.setSelectedTab( selectedTab || this.firstTab, false );
+		}
 	}
 
 	setSelectedTab( currentTab, setFocus ) {
@@ -49,15 +55,19 @@ class TabsAutomatic {
 			const tab = this.tabs[ i ];
 			if ( currentTab === tab ) {
 				tab.setAttribute( 'aria-selected', 'true' );
-				tab.removeAttribute( 'tabindex' );
-				this.tabpanels[ i ].removeAttribute( 'hidden' );
+				tab.tabIndex = 0;
+				if ( this.tabpanels[ i ] ) {
+					this.tabpanels[ i ].removeAttribute( 'hidden' );
+				}
 				if ( setFocus ) {
 					tab.focus();
 				}
 			} else {
 				tab.setAttribute( 'aria-selected', 'false' );
 				tab.tabIndex = -1;
-				this.tabpanels[ i ].setAttribute( 'hidden', true );
+				if ( this.tabpanels[ i ] ) {
+					this.tabpanels[ i ].setAttribute( 'hidden', true );
+				}
 			}
 		}
 	}
@@ -162,14 +172,20 @@ class TabsScrollHandler {
 
 		// Keyboard support for scroll arrows
 		this.leftArrow.addEventListener( 'keydown', ( event ) => {
-			if ( ( event.key === 'Enter' || event.key === ' ' ) && ! this.leftArrow.classList.contains( 'hidden' ) ) {
+			if (
+				( event.key === 'Enter' || event.key === ' ' ) &&
+				! this.leftArrow.classList.contains( 'hidden' )
+			) {
 				event.preventDefault();
 				this.scrollLeft();
 			}
 		} );
 
 		this.rightArrow.addEventListener( 'keydown', ( event ) => {
-			if ( ( event.key === 'Enter' || event.key === ' ' ) && ! this.rightArrow.classList.contains( 'hidden' ) ) {
+			if (
+				( event.key === 'Enter' || event.key === ' ' ) &&
+				! this.rightArrow.classList.contains( 'hidden' )
+			) {
 				event.preventDefault();
 				this.scrollRight();
 			}
@@ -190,7 +206,7 @@ class TabsScrollHandler {
 		const scrollAmount = this.tablist.clientWidth * 0.8;
 		this.tablist.scrollBy( {
 			left: -scrollAmount,
-			behavior: 'smooth'
+			behavior: 'smooth',
 		} );
 	}
 
@@ -198,7 +214,7 @@ class TabsScrollHandler {
 		const scrollAmount = this.tablist.clientWidth * 0.8;
 		this.tablist.scrollBy( {
 			left: scrollAmount,
-			behavior: 'smooth'
+			behavior: 'smooth',
 		} );
 	}
 

--- a/tabs/tabs.php
+++ b/tabs/tabs.php
@@ -5,7 +5,7 @@
  * Description:       A block that allows users to organize content into tabs.
  * Requires at least: 6.5
  * Requires PHP:      8.0
- * Version:           0.1.2
+ * Version:           0.1.3
  * Author:            Automattic Special Projects Team
  * Author URI:        https://specialprojects.automattic.com/
  * License:           GPL-2.0-or-later
@@ -26,6 +26,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * through the block editor in the corresponding context.
  *
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ *
+ * @return void
  */
 function wpcomsp_tabs_block_init() {
 	register_block_type( __DIR__ . '/build/tabs' );


### PR DESCRIPTION
## Summary

Fixes the Tabs block keyboard focus behavior by keeping the selected tab control in the tab order and moving focus when tabs are selected. This makes the frontend tablist keyboard-accessible on initial load, click, and arrow-key navigation.

Also adds a static-block deprecation for the previous saved markup and bumps the Tabs plugin to `0.1.3`.

## Affected plugin(s)

`tabs`

Closes #163

## Type of change

- [x] Bug fix
- [ ] Enhancement to an existing block
- [ ] New block plugin
- [ ] Tooling / docs / CI

## Checklist

- [x] This PR covers a **single block plugin** (block-family exception aside).
- [x] PHP passes **PHPCS + WPCS**: `vendor/bin/phpcs --standard=.phpcs.xml tabs`.
- [x] JS/CSS is **linted and formatted**: `npm run lint:js`, `npm run lint:css`, `npm run format`.
- [x] Tested in the latest **`twenty-*` theme**, including existing saved markup behavior.
- [x] Static-block `edit`/`save` changes include a **block deprecation**.
- [x] Plugin header **`Version:` bumped** and `CHANGELOG.md` / `readme.txt` changelog updated.
- [x] No project-specific styling or data added to the block.

## Screenshots / screencast

Frontend verified on the local fixture page. The selected tab receives focus and `tabindex="0"` after click and arrow-key navigation.


https://github.com/user-attachments/assets/9650e247-e9aa-4b4a-a7d4-e480aa4ae3ef

