### PR TITLE
Update to the inline button style

### DIFF
--- a/bp-groups/bp-groups.php
+++ b/bp-groups/bp-groups.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       BP Groups Blocks
  * Description:       Example block scaffolded with Create Block tool.
- * Version:           0.2.0
+ * Version:           0.2.1
  * Requires at least: 6.8
  * Requires PHP:      7.4
  * Author:            Automattic Special Projects Team

--- a/bp-groups/readme.txt
+++ b/bp-groups/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      wpspecialprojects
 Tags:              block BuddyPress
 Tested up to:      6.8
-Stable tag:        0.2.0
+Stable tag:        0.2.1
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -104,6 +104,9 @@ wp.domReady( () => {
 2. Screenshot of how this looks in the front end.
 
 == Changelog ==
+
+= 0.2.1 =
+Style update for the inline view all button to add inline style variable for widths and height and font size based on button size.
 
 = 0.2.0 =
 Updates to the BP Groups Contributors block.

--- a/bp-groups/src/bp-groups-contributors/edit.js
+++ b/bp-groups/src/bp-groups-contributors/edit.js
@@ -208,18 +208,21 @@ export default function Edit( { attributes, setAttributes } ) {
 							></li>
 						) ) }
 						{ showAvatars && showAllMembersStyle === 'link' && (
-							<li
-								className="bp-groups-contributors__avatar"
-								style={ {
-									backgroundColor: '#ccc',
-									display: 'inline-flex',
-									justifyContent: 'center',
-									alignItems: 'center',
-									width: avatarSize,
-									height: avatarSize,
-								} }
-							>
-								+{ perPage }
+							<li className="bp-groups-contributors__avatar">
+								<span
+									className="bp-groups-contributors__view-all"
+									style={ {
+										backgroundColor: '#ccc',
+										display: 'inline-flex',
+										justifyContent: 'center',
+										alignItems: 'center',
+										width: avatarSize,
+										height: avatarSize,
+										'--avatar-size': avatarSize + 'px',
+									} }
+								>
+									+{ perPage }
+								</span>
 							</li>
 						) }
 					</ul>

--- a/bp-groups/src/bp-groups-contributors/render.php
+++ b/bp-groups/src/bp-groups-contributors/render.php
@@ -82,7 +82,7 @@ $i                 = 1;
 				}
 				if ( $show_avatars && ( $members_count > $members_per_page ) && 'link' === $all_members_style ) {
 					printf(
-						'<li class="bp-groups-contributors__avatar bp-groups-contributors__avatar--more" %s><button data-size="%s" class="bp-groups-contributors__view-all" tabindex="0">%s</button></li>',
+						'<li class="bp-groups-contributors__avatar bp-groups-contributors__avatar--more" %s><button style="--avatar-size: %spx;" class="bp-groups-contributors__view-all" tabindex="0">%s</button></li>',
 						( $members_count > $members_per_page ) ? '' : 'hidden',
 						esc_attr( $size ),
 						esc_html( '+' . ( $members_count - $members_per_page ) )

--- a/bp-groups/src/bp-groups-contributors/style.scss
+++ b/bp-groups/src/bp-groups-contributors/style.scss
@@ -6,7 +6,6 @@
  */
 
 .bp-groups-contributors {
-
 	&__view-all {
 		background-color: transparent;
 		border: none;
@@ -28,11 +27,16 @@
 		&.fade-in {
 			animation: fadeIn 0.3s ease-in-out forwards;
 		}
+
+		.bp-groups-contributors__view-all {
+			height: var(--avatar-size);
+			font-size: calc(var(--avatar-size) * 0.35);
+			width: var(--avatar-size);
+		}
 	}
 }
 
 @keyframes fadeIn {
-
 	from {
 		opacity: 0;
 	}

--- a/bp-groups/src/bp-groups-contributors/style.scss
+++ b/bp-groups/src/bp-groups-contributors/style.scss
@@ -6,6 +6,7 @@
  */
 
 .bp-groups-contributors {
+
 	&__view-all {
 		background-color: transparent;
 		border: none;
@@ -37,6 +38,7 @@
 }
 
 @keyframes fadeIn {
+
 	from {
 		opacity: 0;
 	}


### PR DESCRIPTION
<!-- See CONTRIBUTING.md for the full guidelines. -->

## Summary

Updates the inline button style, so that a css variable is added for the avatar size instead of using a data attribute for better cross platform support in using this information in a style sheet

Added some basic styling for the inline button so the size of the button matches the avatars and added a font size that should be proportionate to the button size

## Affected plugin(s)
bp-groups/bp-groups-contributors

Closes #

## Type of change

- [x] Bug fix
- [x] Enhancement to an existing block
- [ ] New block plugin
- [ ] Tooling / docs / CI

## Checklist

- [x] This PR covers a **single block plugin** (block-family exception aside).
- [ ] PHP passes **PHPCS + WPCS**: `vendor/bin/phpcs --standard=.phpcs.xml <dir>`.
- [x] JS/CSS is **linted and formatted**: `npm run lint:js`, `npm run lint:css`, `npm run format`.
- [ ] Tested in the latest **`twenty-*` theme**, including the `trunk` → branch upgrade path.
- [ ] Static-block `edit`/`save` changes include a **block deprecation**.
- [x] Plugin header **`Version:` bumped** and `CHANGELOG.md` / `readme.txt` changelog updated (for releasable changes).
- [x] No project-specific styling or data added to the block.

## Screenshots / screencast

<!-- Editor and front-end, where relevant. -->
