### PR TITLE
Tabs: Add block transform to `core/tabs`

### DIFF
--- a/tabs/CHANGELOG.md
+++ b/tabs/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Transform the Tabs block into the core Tabs block from the block toolbar. Tab titles, tab order, panel content, anchor, and alignment carry over.
+- Transform the Tabs block into the core Tabs block from the block toolbar. Tab titles, tab order, panel content, anchor, and alignment carry over. Bold and italic in a tab title are kept, but a link is reduced to its text because the core tab list does not accept links. A title with no text falls back to `Tab 1`, `Tab 2`, and so on.
 
 ### Changed
 
-- Hide the block from the inserter on sites where the core Tabs block is available (WordPress 7.1+). Existing content keeps rendering and stays editable. Sites without the core block are unaffected.
+- Document that the core Tabs block supersedes this one from WordPress 7.1. The block stays in the inserter, and existing content keeps rendering and stays editable.
 
 ## 0.1.3
 

--- a/tabs/CHANGELOG.md
+++ b/tabs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.0
+
+### Added
+
+- Transform the Tabs block into the core Tabs block from the block toolbar. Tab titles, tab order, panel content, anchor, and alignment carry over.
+
+### Changed
+
+- Hide the block from the inserter on sites where the core Tabs block is available (WordPress 7.1+). Existing content keeps rendering and stays editable. Sites without the core block are unaffected.
+
 ## 0.1.3
 
 ### Fixed

--- a/tabs/package.json
+++ b/tabs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tabs",
 	"private": true,
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"description": "A block that allows users to organize content into tabs.",
 	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",

--- a/tabs/readme.txt
+++ b/tabs/readme.txt
@@ -2,13 +2,15 @@
 Contributors:      wpspecialprojects
 Tags:              block, tabs, accordion, accessibility, gutenberg
 Tested up to:      6.8
-Stable tag:        0.1.3
+Stable tag:        0.2.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
 A block that lets you organize content into accessible, keyboard-navigable tabs in the WordPress block editor.
 
 == Description ==
+
+**Superseded by the core Tabs block.** WordPress ships its own Tabs block from version 7.1. On sites that have it, this block no longer appears in the inserter, and existing blocks can be converted to the core block from the block toolbar. The plugin remains useful on older sites, and keeps rendering and editing content that was created with it.
 
 Tabs is a Gutenberg block plugin that lets you split content into a set of switchable tabbed panels. It is built from two nested blocks — a parent **Tabs** block and one or more child **Tab** blocks — so each tab panel can hold any blocks you like and is edited directly through the standard block editor interface.
 
@@ -30,7 +32,7 @@ The tab interface follows the ARIA Authoring Practices Guide tablist pattern, so
 
 1. Upload the `tabs` folder to the `/wp-content/plugins/` directory, or install through the WordPress Plugins screen via **Plugins > Add New > Upload Plugin**.
 2. Activate the plugin through the **Plugins** screen in WordPress.
-3. Open any post or page in the block editor, click the **+** inserter, and search for **Tabs**.
+3. Open any post or page in the block editor, click the **+** inserter, and search for **Tabs**. On WordPress 7.1 and later this finds the core Tabs block; on older sites it finds this plugin's block.
 4. Edit each tab's title inline, add content inside each tab panel, and use the toolbar buttons to reorder tabs.
 
 = Building from source =
@@ -43,6 +45,16 @@ Requirements: Node.js 18+.
 4. `npm start` — development build with file watching
 
 == Frequently Asked Questions ==
+
+= Why can't I find the block in the inserter anymore? =
+
+Your site has the core Tabs block, so the inserter offers that one instead. Search for **Tabs** and you will find it. On sites without the core block, this plugin's block stays in the inserter as before.
+
+Note that the block list is built when the editor loads. If you change plugins, reload the editor before you check the inserter.
+
+= How do I convert an existing block to the core Tabs block? =
+
+Select the Tabs block, click the block icon at the left of the block toolbar, and choose **Tabs** under "Transform to". Tab titles, tab order, panel content, the HTML anchor, and the alignment all carry over. The option only appears on sites that have the core Tabs block.
 
 = How do I add or remove tabs? =
 
@@ -69,6 +81,10 @@ When the tab list overflows its container, left and right scroll arrows appear s
 Yes. Each Tab is an inner-blocks container, so a tab panel can hold any blocks. New tabs start with an empty paragraph that you can replace or build on.
 
 == Changelog ==
+
+= 0.2.0 =
+* Add a block transform that converts the Tabs block into the core Tabs block, carrying over tab titles, tab order, panel content, anchor, and alignment.
+* Hide the block from the inserter where the core Tabs block is available, so new content uses the core block.
 
 = 0.1.3 =
 * Fix frontend keyboard focus for tab controls by keeping the selected tab in the tab order.

--- a/tabs/readme.txt
+++ b/tabs/readme.txt
@@ -10,7 +10,7 @@ A block that lets you organize content into accessible, keyboard-navigable tabs 
 
 == Description ==
 
-**Superseded by the core Tabs block.** WordPress ships its own Tabs block from version 7.1. On sites that have it, this block no longer appears in the inserter, and existing blocks can be converted to the core block from the block toolbar. The plugin remains useful on older sites, and keeps rendering and editing content that was created with it.
+**Superseded by the core Tabs block.** WordPress ships its own Tabs block from version 7.1. Prefer the core block for new content. This block stays available in the inserter, and existing blocks can be converted to the core block from the block toolbar. The plugin remains useful on older sites, and keeps rendering and editing content that was created with it.
 
 Tabs is a Gutenberg block plugin that lets you split content into a set of switchable tabbed panels. It is built from two nested blocks — a parent **Tabs** block and one or more child **Tab** blocks — so each tab panel can hold any blocks you like and is edited directly through the standard block editor interface.
 
@@ -32,7 +32,7 @@ The tab interface follows the ARIA Authoring Practices Guide tablist pattern, so
 
 1. Upload the `tabs` folder to the `/wp-content/plugins/` directory, or install through the WordPress Plugins screen via **Plugins > Add New > Upload Plugin**.
 2. Activate the plugin through the **Plugins** screen in WordPress.
-3. Open any post or page in the block editor, click the **+** inserter, and search for **Tabs**. On WordPress 7.1 and later this finds the core Tabs block; on older sites it finds this plugin's block.
+3. Open any post or page in the block editor, click the **+** inserter, and search for **Tabs**. On WordPress 7.1 and later the core Tabs block is listed alongside this plugin's block.
 4. Edit each tab's title inline, add content inside each tab panel, and use the toolbar buttons to reorder tabs.
 
 = Building from source =
@@ -46,15 +46,15 @@ Requirements: Node.js 18+.
 
 == Frequently Asked Questions ==
 
-= Why can't I find the block in the inserter anymore? =
+= There are two Tabs blocks in the inserter. Which one do I use? =
 
-Your site has the core Tabs block, so the inserter offers that one instead. Search for **Tabs** and you will find it. On sites without the core block, this plugin's block stays in the inserter as before.
-
-Note that the block list is built when the editor loads. If you change plugins, reload the editor before you check the inserter.
+From WordPress 7.1 the inserter lists the core **Tabs** block as well as this plugin's block. Use the core block for new content. This plugin's block stays available so that older sites keep working, and so that existing content stays editable.
 
 = How do I convert an existing block to the core Tabs block? =
 
 Select the Tabs block, click the block icon at the left of the block toolbar, and choose **Tabs** under "Transform to". Tab titles, tab order, panel content, the HTML anchor, and the alignment all carry over. The option only appears on sites that have the core Tabs block.
+
+Bold and italic in a tab title are kept. A link in a tab title is reduced to its text, because the core tab list does not accept links inside a tab button. A title with no text becomes **Tab 1**, **Tab 2**, and so on.
 
 = How do I add or remove tabs? =
 
@@ -84,7 +84,7 @@ Yes. Each Tab is an inner-blocks container, so a tab panel can hold any blocks. 
 
 = 0.2.0 =
 * Add a block transform that converts the Tabs block into the core Tabs block, carrying over tab titles, tab order, panel content, anchor, and alignment.
-* Hide the block from the inserter where the core Tabs block is available, so new content uses the core block.
+* Bold and italic in a tab title survive the transform. A link is reduced to its text, because the core tab list does not accept links inside a tab button. A title with no text becomes Tab 1, Tab 2, and so on.
 
 = 0.1.3 =
 * Fix frontend keyboard focus for tab controls by keeping the selected tab in the tab order.

--- a/tabs/src/tab/block.json
+++ b/tabs/src/tab/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "wpcomsp/tab",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"title": "Tab",
 	"category": "widgets",
 	"description": "Customize content inside a tab.",

--- a/tabs/src/tabs/block.json
+++ b/tabs/src/tabs/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "wpcomsp/tabs",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"title": "Tabs",
 	"category": "widgets",
 	"description": "Organize content using tabs.",

--- a/tabs/src/tabs/index.js
+++ b/tabs/src/tabs/index.js
@@ -20,6 +20,7 @@ import Edit from './edit';
 import save from './save';
 import metadata from './block.json';
 import deprecated from './deprecated';
+import transforms from './transforms';
 
 const TabsIcon = (
 	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none">
@@ -37,4 +38,5 @@ registerBlockType( metadata.name, {
 	edit: Edit,
 	save,
 	deprecated,
+	transforms,
 } );

--- a/tabs/src/tabs/transforms.js
+++ b/tabs/src/tabs/transforms.js
@@ -3,12 +3,46 @@
  */
 import { createBlock } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
+import {
+	create,
+	getTextContent,
+	removeFormat,
+	toHTMLString,
+} from '@wordpress/rich-text';
 
 const TAB_BLOCK_NAME = 'wpcomsp/tab';
 const CORE_TABS_BLOCK_NAME = 'core/tabs';
 const CORE_TAB_LIST_BLOCK_NAME = 'core/tab-list';
 const CORE_TAB_PANELS_BLOCK_NAME = 'core/tab-panels';
 const CORE_TAB_PANEL_BLOCK_NAME = 'core/tab-panel';
+
+const LINK_FORMAT_NAME = 'core/link';
+
+/**
+ * Converts a tab title into a label the core tab list accepts.
+ *
+ * @param {string} title Tab title, as rich text.
+ * @param {number} index Position of the tab, starting at 0.
+ *
+ * @return {string} Label as rich text.
+ */
+function toTabLabel( title, index ) {
+	const value = create( { html: title ?? '' } );
+
+	if ( ! getTextContent( value ).trim() ) {
+		return sprintf(
+			/* translators: %d: position of the tab, starting at 1. */
+			__( 'Tab %d', 'tabs' ),
+			index + 1
+		);
+	}
+
+	// The core tab list edits labels with `withoutInteractiveFormatting`, and a
+	// link inside its tab button would be interactive content nested in a control.
+	return toHTMLString( {
+		value: removeFormat( value, LINK_FORMAT_NAME, 0, value.text.length ),
+	} );
+}
 
 const transforms = {
 	to: [
@@ -19,14 +53,8 @@ const transforms = {
 				const tabBlocks = innerBlocks.filter(
 					( block ) => block.name === TAB_BLOCK_NAME
 				);
-				const labels = tabBlocks.map(
-					( { attributes }, index ) =>
-						attributes.title ||
-						sprintf(
-							/* translators: %d: position of the tab, starting at 1. */
-							__( 'Tab %d', 'tabs' ),
-							index + 1
-						)
+				const labels = tabBlocks.map( ( { attributes }, index ) =>
+					toTabLabel( attributes.title, index )
 				);
 
 				return createBlock( CORE_TABS_BLOCK_NAME, { align, anchor }, [

--- a/tabs/src/tabs/transforms.js
+++ b/tabs/src/tabs/transforms.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { __, sprintf } from '@wordpress/i18n';
+
+const TAB_BLOCK_NAME = 'wpcomsp/tab';
+const CORE_TABS_BLOCK_NAME = 'core/tabs';
+const CORE_TAB_LIST_BLOCK_NAME = 'core/tab-list';
+const CORE_TAB_PANELS_BLOCK_NAME = 'core/tab-panels';
+const CORE_TAB_PANEL_BLOCK_NAME = 'core/tab-panel';
+
+const transforms = {
+	to: [
+		{
+			type: 'block',
+			blocks: [ CORE_TABS_BLOCK_NAME ],
+			transform: ( { align, anchor }, innerBlocks ) => {
+				const tabBlocks = innerBlocks.filter(
+					( block ) => block.name === TAB_BLOCK_NAME
+				);
+				const labels = tabBlocks.map(
+					( { attributes }, index ) =>
+						attributes.title ||
+						sprintf(
+							/* translators: %d: position of the tab, starting at 1. */
+							__( 'Tab %d', 'tabs' ),
+							index + 1
+						)
+				);
+
+				return createBlock( CORE_TABS_BLOCK_NAME, { align, anchor }, [
+					createBlock( CORE_TAB_LIST_BLOCK_NAME, {
+						tabs: labels.map( ( label ) => ( { label } ) ),
+					} ),
+					createBlock(
+						CORE_TAB_PANELS_BLOCK_NAME,
+						{},
+						tabBlocks.map( ( tabBlock, index ) =>
+							createBlock(
+								CORE_TAB_PANEL_BLOCK_NAME,
+								{ label: labels[ index ] },
+								tabBlock.innerBlocks
+							)
+						)
+					),
+				] );
+			},
+		},
+	],
+};
+
+export default transforms;

--- a/tabs/tabs.php
+++ b/tabs/tabs.php
@@ -40,17 +40,19 @@ add_action( 'init', 'wpcomsp_tabs_block_init' );
  * Existing content keeps rendering and stays editable, and can be converted
  * to `core/tabs` from the block toolbar.
  *
- * @return void
+ * @param array $metadata Metadata loaded from the `block.json` file.
+ *
+ * @return array
  */
-function wpcomsp_tabs_hide_from_inserter() {
-	$registry = WP_Block_Type_Registry::get_instance();
-	if ( ! $registry->is_registered( 'core/tabs' ) ) {
-		return;
+function wpcomsp_tabs_hide_from_inserter( $metadata ) {
+	if ( 'wpcomsp/tabs' !== $metadata['name'] ) {
+		return $metadata;
 	}
 
-	$block_type = $registry->get_registered( 'wpcomsp/tabs' );
-	if ( $block_type instanceof WP_Block_Type && is_array( $block_type->supports ) ) {
-		$block_type->supports['inserter'] = false;
+	if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/tabs' ) ) {
+		$metadata['supports']['inserter'] = false;
 	}
+
+	return $metadata;
 }
-add_action( 'wp_loaded', 'wpcomsp_tabs_hide_from_inserter' );
+add_filter( 'block_type_metadata', 'wpcomsp_tabs_hide_from_inserter' );

--- a/tabs/tabs.php
+++ b/tabs/tabs.php
@@ -34,25 +34,3 @@ function wpcomsp_tabs_block_init() {
 	register_block_type( __DIR__ . '/build/tab' );
 }
 add_action( 'init', 'wpcomsp_tabs_block_init' );
-
-/**
- * Removes the block from the inserter on sites that ship the core Tabs block.
- * Existing content keeps rendering and stays editable, and can be converted
- * to `core/tabs` from the block toolbar.
- *
- * @param array $metadata Metadata loaded from the `block.json` file.
- *
- * @return array
- */
-function wpcomsp_tabs_hide_from_inserter( $metadata ) {
-	if ( 'wpcomsp/tabs' !== $metadata['name'] ) {
-		return $metadata;
-	}
-
-	if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/tabs' ) ) {
-		$metadata['supports']['inserter'] = false;
-	}
-
-	return $metadata;
-}
-add_filter( 'block_type_metadata', 'wpcomsp_tabs_hide_from_inserter' );

--- a/tabs/tabs.php
+++ b/tabs/tabs.php
@@ -34,3 +34,23 @@ function wpcomsp_tabs_block_init() {
 	register_block_type( __DIR__ . '/build/tab' );
 }
 add_action( 'init', 'wpcomsp_tabs_block_init' );
+
+/**
+ * Removes the block from the inserter on sites that ship the core Tabs block.
+ * Existing content keeps rendering and stays editable, and can be converted
+ * to `core/tabs` from the block toolbar.
+ *
+ * @return void
+ */
+function wpcomsp_tabs_hide_from_inserter() {
+	$registry = WP_Block_Type_Registry::get_instance();
+	if ( ! $registry->is_registered( 'core/tabs' ) ) {
+		return;
+	}
+
+	$block_type = $registry->get_registered( 'wpcomsp/tabs' );
+	if ( $block_type instanceof WP_Block_Type && is_array( $block_type->supports ) ) {
+		$block_type->supports['inserter'] = false;
+	}
+}
+add_action( 'wp_loaded', 'wpcomsp_tabs_hide_from_inserter' );

--- a/tabs/tabs.php
+++ b/tabs/tabs.php
@@ -5,7 +5,7 @@
  * Description:       A block that allows users to organize content into tabs.
  * Requires at least: 6.5
  * Requires PHP:      8.0
- * Version:           0.1.3
+ * Version:           0.2.0
  * Author:            Automattic Special Projects Team
  * Author URI:        https://specialprojects.automattic.com/
  * License:           GPL-2.0-or-later


### PR DESCRIPTION
<!-- See CONTRIBUTING.md for the full guidelines. -->

## Summary

- This adds a block transform to convert `wpcomsp/tabs` into `core/tabs` as of WordPress 7.1.
- It hides our block if `core/tabs` is registered already.

## Affected plugin(s)

`tabs`.

## Type of change

- [ ] Bug fix
- [x] Enhancement to an existing block
- [ ] New block plugin
- [ ] Tooling / docs / CI

## Checklist

- [x] This PR covers a **single block plugin** (block-family exception aside).
- [x] PHP passes **PHPCS + WPCS**: `vendor/bin/phpcs --standard=.phpcs.xml <dir>`.
- [x] JS/CSS is **linted and formatted**: `npm run lint:js`, `npm run lint:css`, `npm run format`.
- [x] Tested in the latest **`twenty-*` theme**, including the `trunk` → branch upgrade path.
- [ ] Static-block `edit`/`save` changes include a **block deprecation**.
- [x] Plugin header **`Version:` bumped** and `CHANGELOG.md` / `readme.txt` changelog updated (for releasable changes).
- [x] No project-specific styling or data added to the block.

## Screenshots / screencast

Here's an example of the transform in place:

https://github.com/user-attachments/assets/6db66e8e-5771-4084-8db7-74edf5e37fde
