### PR TITLE
Modal: Fix deprecated modal outside-click directive (0.1.3)

### DIFF
--- a/modal/CHANGELOG.md
+++ b/modal/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.3 (2026-08-26)
+
+### Fixed
+
+-   Replace deprecated `data-wp-on-async-document` with `data-wp-on-document` and `withSyncEvent()` for outside-click handling.
+
 ## 0.1.2 (2025-10-21)
 
 ### Fixed

--- a/modal/modal.php
+++ b/modal/modal.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Modal
  * Description:       A modal block that can be toggled open and closed.
- * Version:           0.1.2
+ * Version:           0.1.3
  * Requires at least: 6.6
  * Requires PHP:      7.2
  * Author:            Automattic Special Projects Team

--- a/modal/package-lock.json
+++ b/modal/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "modal",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "modal",
-			"version": "0.1.2",
+			"version": "0.1.3",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/interactivity": "^6.9.0"

--- a/modal/package.json
+++ b/modal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "modal",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "An interactive block with the Interactivity API.",
 	"author": "Automattic Special Projects Team",
 	"license": "GPL-2.0-or-later",

--- a/modal/readme.txt
+++ b/modal/readme.txt
@@ -3,7 +3,7 @@ Contributors:      wpspecialprojects
 Tags:              block, modal, dialog, interactivity, accessibility
 Requires at least: 6.6
 Tested up to:      6.8
-Stable tag:        0.1.2
+Stable tag:        0.1.3
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +73,9 @@ Yes. The plugin adds the Modal button to the blocks allowed inside the core Navi
 Yes. A Modal button can be placed inside a modal's content to trigger a second modal. When the second modal closes, focus returns to the button that opened it.
 
 == Changelog ==
+
+= 0.1.3 =
+* Fix: Replace deprecated `data-wp-on-async-document` with `data-wp-on-document` and `withSyncEvent()` for outside-click handling.
 
 = 0.1.2 =
 * Modal block (`a8csp/modal`) built with the Interactivity API: a button that opens an accessible, reusable modal dialog.

--- a/modal/src/block.json
+++ b/modal/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "a8csp/modal",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"title": "Modal",
 	"category": "widgets",
 	"icon": "media-interactive",

--- a/modal/src/render.php
+++ b/modal/src/render.php
@@ -45,7 +45,7 @@ wp_interactivity_state(
 	data-wp-on--click="actions.openModal"
 	data-wp-bind--aria-expanded="state.isModalOpen"
 	data-wp-on--keydown="actions.handleMenuKeydown"
-	data-wp-on-async-document--click="callbacks.handleModalOutsideClick"
+	data-wp-on-document--click="callbacks.handleModalOutsideClick"
 	id="<?php echo esc_attr( $a8csp_blocks_modal_button ); ?>"
 	aria-haspopup="menu"
 >

--- a/modal/src/view.js
+++ b/modal/src/view.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { store, getContext, getElement } from '@wordpress/interactivity';
+import { store, getContext, getElement, withSyncEvent } from '@wordpress/interactivity';
 
 const { actions, state, helpers } = store( 'a8csp/modal', {
 	state: {
@@ -102,7 +102,7 @@ const { actions, state, helpers } = store( 'a8csp/modal', {
 		},
 	},
 	callbacks: {
-		handleModalOutsideClick( event ) {
+		handleModalOutsideClick: withSyncEvent( ( event ) => {
 			const { id } = getContext();
 
 			if ( state.selected !== id ) {
@@ -112,14 +112,14 @@ const { actions, state, helpers } = store( 'a8csp/modal', {
 			if ( 'wp-block-a8csp-modal' === event.target.className ) {
 				return;
 			}
-			
+
 			const modal = helpers.getModal( id );
 			const modalInner = modal.querySelector( '.wp-block-a8csp-modal-container--inner' );
 
 			if ( ! modalInner.contains( event.target ) ) {
 				actions.closeModal();
 			}
-		},
+		} ),
 	},
 	helpers: {
 		getButton: ( button ) => {


### PR DESCRIPTION
Replace data-wp-on-async-document with data-wp-on-document and withSyncEvent() to clear the WordPress 7.0 deprecation notice and version bump to 0.1.3

